### PR TITLE
fix timing issues on systems where RAND_MAX is not INT32_MAX

### DIFF
--- a/src/olsr_switch/link_rules.c
+++ b/src/olsr_switch/link_rules.c
@@ -69,7 +69,7 @@ ohs_check_link(struct ohs_connection *oc, union olsr_ip_addr *dst)
       return 0;
     }
 
-    r = 1 + (int)(100.0 / (RAND_MAX + 1.0) * olsr_random());
+    r = 1 + (int)(100.0 / (OLSR_RANDOM_MAX + 1.0) * olsr_random());
 
     if (logbits & LOG_LINK) {
       struct ipaddr_str addrstr, dststr;

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -614,7 +614,7 @@ calc_jitter(unsigned int rel_time, uint8_t jitter_pct, unsigned int random_val)
    * Play some tricks to avoid overflows with integer arithmetic.
    */
   jitter_time = (jitter_pct * rel_time) / 100;
-  jitter_time = random_val / (1 + RAND_MAX / (jitter_time + 1));
+  jitter_time = random_val / (1 + OLSR_RANDOM_MAX / (jitter_time + 1));
 
   OLSR_PRINTF(3, "TIMER: jitter %u%% rel_time %ums to %ums\n", jitter_pct, rel_time, rel_time - jitter_time);
 


### PR DESCRIPTION
There are systems where RAND_MAX is not the same as INT32_MAX.
Solaris and illumos for example define RAND_MAX to 32767. This is also the minimum value as specified by POSIX.

Values other than INT32_MAX currently break the logic in `calc_jitter()`, resulting in timers firing too early. 
The fix is to use OLSR_RANDOM_MAX from `src/olsr_random.h` instead, which is INT32_MAX.
