### PR TITLE
fix msys/mingw build on win32

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -96,6 +96,7 @@ CC = 		$(CCACHE) gcc
 else
 CC ?= 		$(CCACHE) gcc
 endif
+CC := $(strip $(CC))
 ifeq ($(DEBUG),0)
   ifeq ($(NOSTRIP),0)
   STRIP ?=  strip

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -254,6 +254,9 @@ endif
 LDFLAGS +=	-Wl,-rpath,$(LIBDIR)
 endif
 # LDFLAGS for all 
+ifeq ($(OS),win32)
+  LDFLAGS +=	-static-libgcc -static-libstdc++
+endif
 LDFLAGS +=	-Wl,--warn-common
 # See above at "-ffunction-sections" for an explanation (and why it is disabled).
 #LDOPTS +=	-Wl,--gc-sections

--- a/src/win32/compat.c
+++ b/src/win32/compat.c
@@ -72,6 +72,7 @@
 
 #include "defs.h"
 
+void getFILETIMEoffset(LARGE_INTEGER *t);
 void PError(char *Str);
 void WinSockPError(char *Str);
 
@@ -144,6 +145,70 @@ inet_aton(const char *AddrStr, struct in_addr *Addr)
   return 1;
 }
 #endif /* !defined(MINGW_VERSION) || MINGW_VERSION < 40600 */
+
+/* clock_gettime() is not available on Win32 (unless we link libwinpthread)
+ * this clock_gettime() and dependency getFILETIMEoffset() is based on
+ * http://stackoverflow.com/questions/5404277/porting-clock-gettime-to-windows
+ * thanks to http://stackoverflow.com/users/658776/carl-staelin
+ */
+void
+getFILETIMEoffset(LARGE_INTEGER *t)
+{
+    SYSTEMTIME s;
+    FILETIME f;
+
+    s.wYear = 1970;
+    s.wMonth = 1;
+    s.wDay = 1;
+    s.wHour = 0;
+    s.wMinute = 0;
+    s.wSecond = 0;
+    s.wMilliseconds = 0;
+    SystemTimeToFileTime(&s, &f);
+    t->QuadPart = f.dwHighDateTime;
+    t->QuadPart <<= 32;
+    t->QuadPart |= f.dwLowDateTime;
+}
+
+int
+clock_gettime(int dummy, struct timespec *ts)
+{
+    LARGE_INTEGER           t;
+    FILETIME                f;
+    double                  microseconds;
+    static LARGE_INTEGER    offset;
+    static double           frequencyToMicroseconds;
+    static int              initialized = 0;
+    static BOOL             usePerformanceCounter = 0;
+
+    (void)dummy; /* suppress "unused" warning */
+    if (!initialized) {
+        LARGE_INTEGER performanceFrequency;
+        initialized = 1;
+        usePerformanceCounter = QueryPerformanceFrequency(&performanceFrequency);
+        if (usePerformanceCounter) {
+            QueryPerformanceCounter(&offset);
+            frequencyToMicroseconds = (double)performanceFrequency.QuadPart / 1000000.;
+        } else {
+            getFILETIMEoffset(&offset);
+            frequencyToMicroseconds = 10.;
+        }
+    }
+    if (usePerformanceCounter) QueryPerformanceCounter(&t);
+    else {
+        GetSystemTimeAsFileTime(&f);
+        t.QuadPart = f.dwHighDateTime;
+        t.QuadPart <<= 32;
+        t.QuadPart |= f.dwLowDateTime;
+    }
+
+    t.QuadPart -= offset.QuadPart;
+    microseconds = (double)t.QuadPart / frequencyToMicroseconds;
+    t.QuadPart = microseconds;
+    ts->tv_sec = t.QuadPart / 1000000;
+    ts->tv_nsec = (t.QuadPart % 1000000)*1000;
+    return (0);
+}
 
 char *
 StrError(unsigned int ErrNo)


### PR DESCRIPTION
#19f4185: On Win32, "make" from msys can't handle the space before " gcc" (happens if "CCACHE" is empty). "make" echoes out a "command not found" instead of invoking gcc, so nothing will be compiled at all.

#e1c068e: Win32 doesn't provide clock_gettime(), so linking olsrd fails with an "undefined reference". This patch adds this function (with CLOCK_MONOTONIC behaviour). An alternative way to get this function might be linking against libwinpthread (which implements it as well), but then the build would depend on an additional dll.

#366d485: Binaries created with actual Win32 versions of MinGW depend on libgcc_s_dw2-1.dll (unless linked statically against libgcc). Having to provide additional DLLs would make the installer more complex.