### PR TITLE
nameservice: rename parameter "sighup_interval" to "filewrite_interval"

### DIFF
--- a/lib/nameservice/README_NAMESERVICE
+++ b/lib/nameservice/README_NAMESERVICE
@@ -41,6 +41,7 @@ PlParam "IP.ADDR" "another-name.mesh"
 PlParam "hosts-file" "/path/to/hosts_file"
 	which file to write to (usually /etc/hosts).
 	(default: /var/run/hosts_olsr)
+	Also see option "filewrite_interval".
 
 PlParam "suffix" ".olsr"
 	local suffix which is appended to all received names.
@@ -49,6 +50,8 @@ PlParam "suffix" ".olsr"
 PlParam "add-hosts" "/path/to/file"
 	copy contents of this additional hosts file to output file.
 	this is practical if you alreay use your /etc/hosts file.
+	Also see option "filewrite_interval", how often the file
+	is read.
 
 PlParam "dns-server" "IP.ADDR"
 	anounce that this IP has a full (upstream) DNS server. if 
@@ -60,6 +63,7 @@ PlParam "resolv-file" "/path/to/resolv.conf"
 	path to resolv.conf file (usually /etc/resolv.conf)
 	if set, the 3 nearest (best ETX) upstream nameservers annonced 
 	by other nodes in the network are written to this file
+	Also see option "filewrite_interval".
 
 PlParam "interval" "SEC"
 	interval for sending NAME messages in seconds.
@@ -95,6 +99,8 @@ PlParam "latlon-file" "/var/run/latlon.js"
 	/* One or more links between nodes */
 	Link('fromip','toip',lq,nlq,etx);
 
+	Also see option "filewrite_interval".
+
 PlParam "latlon-infile" "name-of-input.txt"
 	Filename to read lat/lon positions from. Meant to be used
 	by a walking GPS receiver. Just write comma separated decimal
@@ -106,27 +112,27 @@ PlParam "sighup-pid-file" "/path/to/pidfile.pid"
         by the pidfile (usually /var/run/dnsmasq.pid) when the host name
         table changes. This is useful for letting dnsmasq or bind know
         they have to reload their hosts file.
-
-PlParam "sighup-interval" "SEC"
-	(*nix systems only) Interval for sending HUP signals in seconds.
-	(default: 5 seconds)
+        Also see option "filewrite_interval".
 
 PlParam "name-change-script" "/path/to/script"
         Script to execute when there is a change in the hosts names
         table. Useful for executing a script that uses the hosts file
         to keep a website or a database updated.
+        Also see option "filewrite_interval".
 
 PlParam "service" "http://me.olsr:80|tcp|my little homepage"
         Add a new service announcement to be spreaded in the mesh.
 
 PlParam "services-file" "/path/to/services_file"
 	File to write (default: /var/run/services_olsr)
+	Also see option "filewrite_interval".
 
 PlParam "services-change-script" "/path/to/script"
         Similar to the previous parameter. Script to execute when there
         is a change in the services list propagated by the nameserver
         plugin. Useful for executing a script that uses the services file
         to keep a website or a database updated.
+        Also see option "filewrite_interval".
 
 PlParam "mac" "xx:xx:xx:xx:xx:xx[,0-255]"
         Add a new MAC addr to be spreaded in the mesh. This MAC addr
@@ -135,12 +141,18 @@ PlParam "mac" "xx:xx:xx:xx:xx:xx[,0-255]"
 
 PlParam "macs-file" "/path/to/macs_file"
 	File to write (default: /var/run/macs_olsr)
+	Also see option "filewrite_interval".
 
 PlParam "macs-change-script" "/path/to/script"
         Similar to the previous parameter. Script to execute when there
         is a change in the macs list propagated by the nameserver
         plugin. Useful for executing a script that uses the services file
         to keep a website or a database updated.
+        Also see option "filewrite_interval".
+
+PlParam "filewrite-interval" "SEC"
+	Interval for writing the status-files to disk, defined in seconds.
+	(default: 5 seconds)
 
 ---------------------------------------------------------------------
 SAMPLE CONFIG
@@ -201,4 +213,4 @@ TODO
   * or make dynamic DNS updates for bind?
 
 ---------------------------------------------------------------------
-EOF / 30.06.2007
+EOF / 12.01.2017

--- a/lib/nameservice/src/nameservice.c
+++ b/lib/nameservice/src/nameservice.c
@@ -84,7 +84,7 @@ static bool nameservice_configured = false;
 /* config parameters */
 static char my_hosts_file[MAX_FILE + 1];
 static char my_sighup_pid_file[MAX_FILE + 1];
-static int my_sighup_interval = 5;
+static int my_filewrite_interval = 5;
 
 static char my_add_hosts[MAX_FILE + 1];
 static char my_suffix[MAX_SUFFIX];
@@ -269,7 +269,7 @@ static const struct olsrd_plugin_parameters plugin_parameters[] = {
   { .name = "interval",               .set_plugin_parameter = &set_plugin_int,         .data = &my_interval },
   { .name = "timeout",                .set_plugin_parameter = &set_nameservice_float,  .data = &my_timeout },
   { .name = "sighup-pid-file",        .set_plugin_parameter = &set_plugin_string,      .data = &my_sighup_pid_file,        .addon = {sizeof(my_sighup_pid_file)} },
-  { .name = "sighup-interval",        .set_plugin_parameter = &set_plugin_int,         .data = &my_sighup_interval },
+  { .name = "filewrite-interval",     .set_plugin_parameter = &set_plugin_int,         .data = &my_filewrite_interval },
   { .name = "hosts-file",             .set_plugin_parameter = &set_plugin_string,      .data = &my_hosts_file,             .addon = {sizeof(my_hosts_file)} },
   { .name = "name-change-script",     .set_plugin_parameter = &set_plugin_string,      .data = &my_name_change_script,     .addon = {sizeof(my_name_change_script)} },
   { .name = "services-change-script", .set_plugin_parameter = &set_plugin_string,      .data = &my_services_change_script, .addon = {sizeof(my_services_change_script)} },
@@ -565,7 +565,7 @@ olsr_start_write_file_timer(void)
     return;
   }
 
-  write_file_timer = olsr_start_timer(my_sighup_interval * MSEC_PER_SEC, 5, OLSR_TIMER_ONESHOT, olsr_expire_write_file_timer, NULL, 0);
+  write_file_timer = olsr_start_timer(my_filewrite_interval * MSEC_PER_SEC, 5, OLSR_TIMER_ONESHOT, olsr_expire_write_file_timer, NULL, 0);
 }
 
 /*


### PR DESCRIPTION
playing around with the new option "sighup_interval" I found, that this also controls the interval of calling the "name-change-script".
Checking the code points out that this is the main-timer for writing any status-file to disk. So it's more consistent to change the parameter-name to what it's really doing.

Also update the README to reference this parameter in the others affected by it.

See #15 