### PR TITLE
fix segfault when printing "You must be root"

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -90,7 +90,7 @@ extern FILE *debug_handle;
 #define OLSR_PRINTF(lvl, format, args...) do { } while(0)
 #else /* NODEBUG */
 #define OLSR_PRINTF(lvl, format, args...) do {                    \
-    if((olsr_cnf->debug_level >= (lvl)) && debug_handle)          \
+    if((!olsr_cnf || olsr_cnf->debug_level >= (lvl)) && debug_handle)          \
       fprintf(debug_handle, (format), ##args);                    \
   } while (0)
 #endif /* NODEBUG */


### PR DESCRIPTION
When olsr_cnf is NULL, always print OLSR_PRINTF messages to avoid segfault.

I compiled olsrd and ran ./olsrd --help, resulting in a segfault.
That's because main.c prints an error message even before the config is loaded,
so that OLSR_PRINTF tries to lookup the logging level in a NULL olsr_cnf.