### PR TITLE
fix: don't attempt to cleanup uninitialized multiGwTunnels

### DIFF
--- a/src/gateway.c
+++ b/src/gateway.c
@@ -426,13 +426,16 @@ static bool multiGwRunScript(const char * mode, bool addMode, const char * ifNam
  */
 static void multiGwTunnelsCleanup(bool add) {
   bool ipv4 = (olsr_cnf->ip_version == AF_INET);
+  struct interfaceName * interfaceNames = ipv4 ? sgwTunnel4InterfaceNames : sgwTunnel6InterfaceNames;
 
   unsigned int i = 0;
   uint8_t count = olsr_cnf->smart_gw_use_count;
 
-  while (++i <= count) {
-    struct interfaceName * ifn = ipv4 ? &sgwTunnel4InterfaceNames[count - i] : &sgwTunnel6InterfaceNames[count - i];
+  if (!interfaceNames)
+    return;
 
+  while ((++i) <= count) {
+    struct interfaceName * ifn = &interfaceNames[count - i];
     unsigned int ifindex = if_nametoindex(ifn->name);
     if (!ifindex) {
       continue;


### PR DESCRIPTION
If olsr_cnf->smart_gw_use_count is 1, no multi-gw tunnels are initialized, and
the sgwTunnel4InterfaceNames and sgwTunnel6InterfaceNames are actually NULL. Do
not attempt to cleanup those if NULL.

Symptom: stopping olsrd e.g. via SIGINT leads to a segfault during cleanup.
The reason is that smart_gw_use_count is 1, which attempts to then dereference
one of sgwTunnel{4,6}InterfaceNames[0], amounting to <NULL>[0].