### PR TITLE
add SmartGatewayBlacklist feature

### DIFF
--- a/README-Olsr-Extensions
+++ b/README-Olsr-Extensions
@@ -348,6 +348,12 @@ All other parameters will be ignored if SmartGateway is set to "no"
    and its ETX is below the value of this setting then the resulting gateway
    costs are equal to the ETX, otherwise the normal calculation of the
    gateway costs applies (default is 2560).
+16-SmartGatewayBlacklist: List of IPv4 and/or IPv6 addresses to never pick as
+   gateway; address ranges in slash-notation (10.20.0.0/16 or ca:ff:ee::1/64)
+   are also allowed to exclude entire subnets. If you know that a particular
+   gateway is currently broken even though it is still actively advertising its
+   uplink on the mesh, add it to the blacklist to never choose it no matter how
+   good its rating may appear.
 
    If SmartGatewayDividerEtx is zero then no weighing is performed (classical
    behaviour). Classical behaviour only takes ETX costs into account when

--- a/src/cfgparser/olsrd_conf.c
+++ b/src/cfgparser/olsrd_conf.c
@@ -1519,6 +1519,18 @@ ip_prefix_list_find(struct ip_prefix_list *list, const union olsr_ip_addr *net, 
   return NULL;
 }
 
+struct ip_prefix_list *
+ip_prefix_list_match(struct ip_prefix_list *list, const union olsr_ip_addr *addr)
+{
+  struct ip_prefix_list *h;
+  for (h = list; h != NULL; h = h->next) {
+    if (ip_in_net(addr, &h->net)) {
+      return h;
+    }
+  }
+  return NULL;
+}
+
 void set_derived_cnf(struct olsrd_config * cnf) {
   if (!cnf->lock_file) {
     cnf->lock_file = olsrd_get_default_lockfile(cnf);

--- a/src/cfgparser/oscan.lex
+++ b/src/cfgparser/oscan.lex
@@ -679,6 +679,12 @@ IPV6ADDR {IPV6PAT1}|{IPV6PAT2}|{IPV6PAT3}|{IPV6PAT4}|{IPV6PAT5}|{IPV6PAT6}|{IPV6
     return TOK_SMART_GW_PREFIX;
 }
 
+"SmartGatewayBlacklist" {
+    olsrd_config_checksum_add(yytext, yyleng);
+    yylval = NULL;
+    return TOK_SMART_GW_BLACKLIST;
+}
+
 "SrcIpRoutes" {
     olsrd_config_checksum_add(yytext, yyleng);
     yylval = NULL;

--- a/src/olsr_cfg.h
+++ b/src/olsr_cfg.h
@@ -350,6 +350,7 @@ struct olsrd_config {
   uint32_t smart_gw_downlink;
   bool smart_gateway_bandwidth_zero;
   struct olsr_ip_prefix smart_gw_prefix;
+  struct ip_prefix_list *smart_gw_blacklist;
 
   /* Main address of this node */
   union olsr_ip_addr main_addr;

--- a/src/olsr_cfg.h
+++ b/src/olsr_cfg.h
@@ -417,6 +417,7 @@ extern "C" {
   int ip_prefix_list_remove(struct ip_prefix_list **, const union olsr_ip_addr *, uint8_t);
 
   struct ip_prefix_list *ip_prefix_list_find(struct ip_prefix_list *, const union olsr_ip_addr *net, uint8_t prefix_len);
+  struct ip_prefix_list *ip_prefix_list_match(struct ip_prefix_list *, const union olsr_ip_addr *addr);
 
 /*
  * Interface to parser


### PR DESCRIPTION
Provide a blacklist for gateway IP addresses so that a user can actively avoid
smart gateways that are advertised on the mesh without actually providing a
usable uplink.

Add SmartGatewayBlacklist to olsrd.conf, a list of IP addresses and/or address
ranges which are always excluded from the smart gateway choice.

Describe in README-Olsr-Extensions and olsrd.conf.default.txt.

Adjust oparse.y and oscan.lex to read in this list and store in
olsr_cnf->smart_gw_blacklist.

Add function ip_prefix_list_match() to return an entry of an ip_prefix_list
that includes the given IP address, used to match a gateway with entries in the
SmartGatewayBlacklist.

Add function isGwBlacklisted() to return nonzero when a given gw address
matches one of the blacklist entries, and to output debug info on level 2 that
a gateway was not considered, and which blacklist entry was responsible.

In gw_default_choose_gateway(), use isGwBlacklisted() to avoid any smartgw
matching an entry in the blacklist.

Rationale: so far olsrd may be stuck on specific smart gws without any means to
avoid broken or overloaded ones; any such broken gw not delivering on its
uplink promises can attract numerous clients' routing (e.g. because it has less
hops), thus actively disrupting service across a mesh segment. This patch
allows avoiding such service disruption by excluding gateways that are known to
be broken without having to rely on unknown/unreachable maintainers of that
node to fix it.

Signed-off-by: Neels Hofmeyr <neels@hofmeyr.de>