### PR TITLE
Add a missing include for olsr_random() on BSD.

### DIFF
--- a/src/bsd/net.c
+++ b/src/bsd/net.c
@@ -55,6 +55,7 @@
 #include "ipcalc.h"
 #include "parser.h"          /* dnc: needed for call to packet_parser() */
 #include "olsr_protocol.h"
+#include "olsr_random.h"
 #include "olsr_cfg.h"
 #include "olsr.h"
 


### PR DESCRIPTION
Signed-off-by: Stefan Sperling <stsp@stsp.name>