### PR TITLE
Implement a simpler way of detecting wifi interfaces on BSD.

### DIFF
--- a/src/bsd/net.c
+++ b/src/bsd/net.c
@@ -64,6 +64,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <net/if.h>
+#include <net/if_media.h>
 #include <sys/ioctl.h>
 #include <fcntl.h>
 #include <syslog.h>
@@ -86,7 +87,6 @@
 #ifdef __NetBSD__
 #include <net/if_ether.h>
 #include <netinet6/in6_var.h>   /* For struct in6_ifreq */
-#include <net80211/ieee80211_ioctl.h>
 #include <ifaddrs.h>
 #endif /* __NetBSD__ */
 
@@ -100,8 +100,6 @@
 #include <netinet6/in6_var.h>   /* For struct in6_ifreq */
 #include <ifaddrs.h>
 #include <sys/uio.h>
-#include <net80211/ieee80211.h>
-#include <net80211/ieee80211_ioctl.h>
 #endif /* __OpenBSD__ */
 
 #if defined __FreeBSD__ || defined __FreeBSD_kernel__
@@ -109,10 +107,6 @@
 #include <net/ethernet.h>
 #include <netinet/in_var.h>
 #include <ifaddrs.h>
-#ifndef FBSD_NO_80211
-#include <net80211/ieee80211.h>
-#include <net80211/ieee80211_ioctl.h>
-#endif /* FBSD_NO_80211 */
 #endif /* defined __FreeBSD__ || defined __FreeBSD_kernel__ */
 
 #ifdef __APPLE__
@@ -747,39 +741,12 @@ olsr_select(int nfds, fd_set * readfds, fd_set * writefds, fd_set * exceptfds, s
 int
 check_wireless_interface(char *ifname)
 {
-#if (defined __FreeBSD__ || defined __FreeBSD_kernel__ ) &&  !defined FBSD_NO_80211
-
-/* From FreeBSD ifconfig/ifieee80211.c ieee80211_status() */
-  struct ieee80211req ireq;
-  u_int8_t data[32];
-
-  memset(&ireq, 0, sizeof(ireq));
-  strscpy(ireq.i_name, ifname, sizeof(ireq.i_name));
-  ireq.i_data = &data;
-  ireq.i_type = IEEE80211_IOC_SSID;
-  ireq.i_val = -1;
-  return (ioctl(olsr_cnf->ioctl_s, SIOCG80211, &ireq) >= 0) ? 1 : 0;
-#elif defined __OpenBSD__
-  struct ieee80211_nodereq nr;
-  bzero(&nr, sizeof(nr));
-  strscpy(nr.nr_ifname, ifname, sizeof(nr.nr_ifname));
-  return (ioctl(olsr_cnf->ioctl_s, SIOCG80211FLAGS, &nr) >= 0) ? 1 : 0;
-#elif defined __NetBSD__
-  struct ifreq ireq;
-  struct ieee80211_nwid data;
+  struct ifmediareq ifmr;
   int ret;
-
-  memset(&ireq, 0, sizeof(ireq));
-  strscpy(ireq.ifr_name, ifname, sizeof(ireq.ifr_name));
-  ireq.ifr_data = &data;
-  ret = ioctl(olsr_cnf->ioctl_s, SIOCG80211NWID, &ireq);
-  if(ret == 0)
-	  return 1;
-  return 0;
-#else /* defined __NetBSD__ */
-  ifname = NULL;                /* squelsh compiler warning */
-  return 0;
-#endif /* defined __NetBSD__ */
+  bzero(&ifmr, sizeof(ifmr));
+  strscpy(ifmr.ifm_name, ifname, sizeof(ifmr.ifm_name));
+  ret = ioctl(olsr_cnf->ioctl_s, SIOCGIFMEDIA, (caddr_t)&ifmr);
+  return (ret == 0 && IFM_TYPE(ifmr.ifm_current) == IFM_IEEE80211);
 }
 
 #include <sys/sockio.h>


### PR DESCRIPTION
The media type of an interface can be used to tell wireless interfaces
apart. The SIOCGIFMEDIA ioctl works the same way across all BSDs,
whereas the net80211 ioctls used previously differ.

Signed-off-by: Stefan Sperling <stsp@stsp.name>