### PR TITLE
Fix olsr_sendto() for IPv4 on BSD.

### DIFF
--- a/src/bsd/net.c
+++ b/src/bsd/net.c
@@ -341,6 +341,12 @@ getsocket(int bufspace, struct interface_olsr *ifp __attribute__ ((unused)))
     return -1;
   }
 
+  if (setsockopt(sock, IPPROTO_IP, IP_MULTICAST_IF, &ifp->int_addr.sin_addr.s_addr, sizeof(struct in_addr)) < 0) {
+    perror("IP_MULTICAST_IF failed");
+    close(sock);
+    return -1;
+  }
+
   if(bufspace > 0) {
     for (on = bufspace;; on -= 1024) {
       if (setsockopt(sock, SOL_SOCKET, SO_RCVBUF, (char *)&on, sizeof(on)) == 0)


### PR DESCRIPTION
Sending multicast packets requires the IP_MULTICAST_IF socket option.
Without this socket option, packets sent to 255.255.255.255 are dropped.

With this change, olsr_sendto() can become a direct call to sendto() and
the -DSPOOF workaround which relies on libnet to send packets is no
longer required.

Tested on OpenBSD.

Signed-off-by: Stefan Sperling <stsp@stsp.name>