### PR TITLE
Use correct RTM flags while deleting a route on BSD.

### DIFF
--- a/src/bsd/kernel_routes.c
+++ b/src/bsd/kernel_routes.c
@@ -226,7 +226,7 @@ add_del_route(const struct rt_entry *rt, int add)
     drtm->rtm_version = RTM_VERSION;
     drtm->rtm_type = RTM_DELETE;
     drtm->rtm_index = 0;
-    drtm->rtm_flags = olsr_rt_flags(rt, add);
+    drtm->rtm_flags = olsr_rt_flags(rt, 0);
     drtm->rtm_seq = ++seq;
 
     walker = dbuff + sizeof(struct rt_msghdr);


### PR DESCRIPTION
If a route to a given destination already exists, the add_del_route()
function attempts to delete this route before inserting a new one.
While doing so, it asks olsr_rt_flags() for route message flags to use.

It should ask for route message flags that apply to a deletion. However,
it only did so if the 'add' parameter is false. This looks like a case of
badly copy-pasted code, since this section of code is obviously trying
to delete a route regardless of the value of 'add'.

Signed-off-by: Stefan Sperling <stsp@stsp.name>