### PR TITLE
Do not toggle net.inet6.icmp6.rediraccept on OpenBSD.

### DIFF
--- a/src/bsd/net.c
+++ b/src/bsd/net.c
@@ -187,8 +187,16 @@ net_os_set_global_ifoptions(void) {
 
   /* do not accept ICMP redirects */
 
-#if defined(__OpenBSD__) || defined(__NetBSD__)
-  if (olsr_cnf->ip_version == AF_INET)
+#if defined(__OpenBSD__)
+  if (olsr_cnf->ip_version == AF_INET) {
+    name = "net.inet.icmp.rediraccept";
+    ignore_redir = set_sysctl_int(name, 0);
+  } else {
+    /* OpenBSD enables icmp6 rediraccept only if IPv6 autoconf is used. */
+    ignore_redir = 1;
+  }
+#elif defined(__NetBSD__)
+  if (olsr_cnf->ip_version == AF_INET) {
     name = "net.inet.icmp.rediraccept";
   else
     name = "net.inet6.icmp6.rediraccept";


### PR DESCRIPTION
OpenBSD no longer supports the net.inet6.icmp6.rediraccept sysctl.
It was removed in 2014: http://marc.info/?l=openbsd-cvs&m=140914827732101&w=2

Signed-off-by: Stefan Sperling <stsp@stsp.name>