### PR TITLE
Use correct RTM flags while deleting an IPv6 route on BSD.

### DIFF
--- a/src/bsd/kernel_routes.c
+++ b/src/bsd/kernel_routes.c
@@ -394,7 +394,7 @@ add_del_route6(const struct rt_entry *rt, int add)
     drtm->rtm_version = RTM_VERSION;
     drtm->rtm_type = RTM_DELETE;
     drtm->rtm_index = 0;
-    drtm->rtm_flags = olsr_rt_flags(rt, add);
+    drtm->rtm_flags = olsr_rt_flags(rt, 0);
     drtm->rtm_seq = ++seq;
 
     walker = dbuff + sizeof(struct rt_msghdr);


### PR DESCRIPTION
Same problem as fixed for IPv4 in 65978bd6996c8f62ac3f0adf971692fc8f2dc9cb.
I forgot to include the IPv6 code path in that commit.

Signed-off-by: Stefan Sperling <stsp@stsp.name>