### PR TITLE
Fix initialization of a struct sockaddr_in.

### DIFF
--- a/src/unix/ifnet.c
+++ b/src/unix/ifnet.c
@@ -632,7 +632,9 @@ chk_if_up(struct olsr_if *iface, int debuglvl __attribute__ ((unused)))
     /* Find broadcast address */
     if (iface->cnf->ipv4_multicast.v4.s_addr) {
       /* Specified broadcast */
-      memcpy(&((struct sockaddr_in *)&ifs.int_broadaddr)->sin_addr.s_addr, &iface->cnf->ipv4_multicast.v4, sizeof(uint32_t));
+      struct sockaddr_in *sin = &ifs.int_broadaddr;
+      memcpy(&sin->sin_addr.s_addr, &iface->cnf->ipv4_multicast.v4, sizeof(uint32_t));
+      sin->sin_family = AF_INET;
     } else {
       /* Autodetect */
       struct sockaddr* ifrb;


### PR DESCRIPTION
While reading an IPv4 broadcast address from the configuration file,
do not forget about initializing the family sockaddr_in struct field.
Otherwise the sockaddr_in struct is invalid, and a BSD kernel will reject it.

Signed-off-by: Stefan Sperling <stsp@stsp.name>