### PR TITLE
Allow reproducible building

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -303,7 +303,7 @@ endif
 CPPFLAGS +=     -DUSE_FPM
 
 # search sources and headers in current dir and in src/
-SRCS +=		$(wildcard src/common/*.c src/*.c *.c)
+SRCS +=		$(sort $(wildcard src/common/*.c src/*.c *.c))
 HDRS +=		$(wildcard src/common/*.h src/*.h *.h)
 
 ifeq ($(OS),UNKNOWN)

--- a/contrib/netsimpcap/Makefile
+++ b/contrib/netsimpcap/Makefile
@@ -41,7 +41,7 @@
 # the copyright holders.
 #
 
-SRC +=	$(wildcard ./src/*.c)
+SRC +=	$(sort $(wildcard ./src/*.c))
 
 OBJS = $(SRC:.c=.o)
 

--- a/lib/httpinfo/src/olsrd_httpinfo.c
+++ b/lib/httpinfo/src/olsrd_httpinfo.c
@@ -822,7 +822,7 @@ build_config_body(struct autobuf *abuf)
   const struct plugin_param *pparam;
   struct ipaddr_str mainaddrbuf;
 
-  abuf_appendf(abuf, "Version: %s (built on %s on %s)\n<br>", olsrd_version, build_date, build_host);
+  abuf_appendf(abuf, "Version: %s\n<br>", olsrd_version);
   abuf_appendf(abuf, "OS: %s\n<br>", OS);
 
   {
@@ -1554,11 +1554,10 @@ build_about_body(struct autobuf *abuf)
 {
   abuf_appendf(abuf,
                   "<strong>" PLUGIN_NAME "</strong><br/><br/>\n"
-                  "Compiled "
 #ifdef ADMIN_INTERFACE
-                  "<em>with experimental admin interface</em> "
+                  "<em>Compiled with experimental admin interface</em>\n"
 #endif /* ADMIN_INTERFACE */
-                  "%s at %s<hr/>\n" "This plugin implements a HTTP server that supplies\n"
+                  "This plugin implements a HTTP server that supplies\n"
                   "the client with various dynamic web pages representing\n"
                   "the current olsrd status.<br/>The different pages include:\n"
                   "<ul>\n<li><strong>Configuration</strong> - This page displays information\n"
@@ -1586,8 +1585,7 @@ build_about_body(struct autobuf *abuf)
                   "<li><strong>About</strong> - this help page.</li>\n</ul>" "<hr/>\n" "Send questions or comments to\n"
                   "<a href=\"mailto:olsr-users@olsr.org\">olsr-users@olsr.org</a> or\n"
                   "<a href=\"mailto:andreto-at-olsr.org\">andreto-at-olsr.org</a><br/>\n"
-                  "Official olsrd homepage: <a href=\"http://www.olsr.org/\">http://www.olsr.org</a><br/>\n", build_date,
-                  build_host);
+                  "Official olsrd homepage: <a href=\"http://www.olsr.org/\">http://www.olsr.org</a><br/>\n");
 }
 
 static void

--- a/lib/jsoninfo/Makefile
+++ b/lib/jsoninfo/Makefile
@@ -48,7 +48,7 @@ PLUGIN_VER =	1.1
 TOPDIR =	../..
 include $(TOPDIR)/Makefile.inc
 
-COMMONINFO = $(wildcard ../info/*.c)
+COMMONINFO = $(sort $(wildcard ../info/*.c))
 OBJS += $(COMMONINFO:%.c=%.o)
 
 default_target: $(PLUGIN_FULLNAME)

--- a/lib/jsoninfo/src/olsrd_jsoninfo.c
+++ b/lib/jsoninfo/src/olsrd_jsoninfo.c
@@ -1089,8 +1089,6 @@ void ipc_print_version(struct autobuf *abuf) {
 
   abuf_json_string(&json_session, abuf, "version", olsrd_version);
 
-  abuf_json_string(&json_session, abuf, "date", build_date);
-  abuf_json_string(&json_session, abuf, "host", build_host);
   abuf_json_string(&json_session, abuf, "gitDescriptor", git_descriptor);
   abuf_json_string(&json_session, abuf, "gitSha", git_sha);
   abuf_json_string(&json_session, abuf, "releaseVersion", release_version);

--- a/lib/netjson/Makefile
+++ b/lib/netjson/Makefile
@@ -48,7 +48,7 @@ PLUGIN_VER =	1.1
 TOPDIR =	../..
 include $(TOPDIR)/Makefile.inc
 
-COMMONINFO = $(wildcard ../info/*.c)
+COMMONINFO = $(sort $(wildcard ../info/*.c))
 OBJS += $(COMMONINFO:%.c=%.o)
 
 default_target: $(PLUGIN_FULLNAME)

--- a/lib/pud/nmealib/Makefile
+++ b/lib/pud/nmealib/Makefile
@@ -17,7 +17,7 @@ INCLUDEDIR ?= $(DESTDIR)/usr/include
 LIBDIR ?= $(USRDIR)/lib
 
 H_FILES = $(wildcard include/nmealib/*.h)
-C_FILES = $(wildcard src/*.c)
+C_FILES = $(sort $(wildcard src/*.c))
 
 MODULES = $(C_FILES:src/%.c=%)
 

--- a/lib/txtinfo/Makefile
+++ b/lib/txtinfo/Makefile
@@ -48,7 +48,7 @@ PLUGIN_VER =	1.1
 TOPDIR =	../..
 include $(TOPDIR)/Makefile.inc
 
-COMMONINFO = $(wildcard ../info/*.c)
+COMMONINFO = $(sort $(wildcard ../info/*.c))
 OBJS += $(COMMONINFO:%.c=%.o)
 
 default_target: $(PLUGIN_FULLNAME)

--- a/lib/txtinfo/src/olsrd_txtinfo.c
+++ b/lib/txtinfo/src/olsrd_txtinfo.c
@@ -562,7 +562,7 @@ void ipc_print_sgw(struct autobuf *abuf) {
 }
 
 void ipc_print_version(struct autobuf *abuf) {
-  abuf_appendf(abuf, "Version: %s (built on %s on %s)\n", olsrd_version, build_date, build_host);
+  abuf_appendf(abuf, "Version: %s\n", olsrd_version);
   abuf_puts(abuf, "\n");
 }
 

--- a/make/Makefile.android
+++ b/make/Makefile.android
@@ -84,7 +84,7 @@ SHAREDIR = $(DESTDIR)$(datarootdir)
 
 # there probably should be an Android log.c and misc.c to support
 # Logcat, but this works for now
-SRCS += $(wildcard src/unix/*.c src/linux/*.c)
+SRCS += $(sort $(wildcard src/unix/*.c src/linux/*.c))
 HDRS += $(wildcard src/unix/*.h src/linux/*.h)
 
 CPPFLAGS +=	-DOLSRD_GLOBAL_CONF_FILE=\"$(CFGFILE)\"

--- a/make/Makefile.fbsd
+++ b/make/Makefile.fbsd
@@ -52,7 +52,7 @@ LIBDIR = $(PREFIX)/lib
 DOCDIR = $(PREFIX)/share/doc
 MANDIR = $(PREFIX)/man
 
-SRCS +=		$(wildcard src/bsd/*.c) $(wildcard src/unix/*.c)
+SRCS +=		$(sort $(wildcard src/bsd/*.c) $(wildcard src/unix/*.c))
 HDRS +=		$(wildcard src/bsd/*.h) $(wildcard src/unix/*.h)
 
 LIBS =

--- a/make/Makefile.kfbsd
+++ b/make/Makefile.kfbsd
@@ -47,7 +47,7 @@
 
 PREFIX ?= /usr/local
 
-SRCS +=		$(wildcard src/bsd/*.c) $(wildcard src/unix/*.c)
+SRCS +=		$(sort $(wildcard src/bsd/*.c) $(wildcard src/unix/*.c))
 HDRS +=		$(wildcard src/bsd/*.h) $(wildcard src/unix/*.h)
 
 LIBS =

--- a/make/Makefile.linux
+++ b/make/Makefile.linux
@@ -60,7 +60,7 @@ MANDIR =	$(DESTDIR)$(mandir)
 SBINDIR =	$(DESTDIR)$(sbindir)
 SHAREDIR =	$(DESTDIR)$(datarootdir)
 
-SRCS += 	$(wildcard src/linux/*.c src/unix/*.c)
+SRCS +=		$(sort $(wildcard src/linux/*.c src/unix/*.c))
 HDRS +=		$(wildcard src/linux/*.h src/unix/*.h)
 
 CPPFLAGS +=

--- a/make/Makefile.nbsd
+++ b/make/Makefile.nbsd
@@ -48,7 +48,7 @@
 DESTDIR ?=
 LIBDIR =	$(DESTDIR)/usr/lib
 
-SRCS +=		$(wildcard src/bsd/*.c src/unix/*.c)
+SRCS +=		$(sort $(wildcard src/bsd/*.c src/unix/*.c))
 HDRS +=		$(wildcard src/bsd/*.h src/unix/*.h)
 
 CPPFLAGS +=	-D__NetBSD__

--- a/make/Makefile.obsd
+++ b/make/Makefile.obsd
@@ -55,7 +55,7 @@ RCDIR =         /etc/rc.d
 
 RCFILE =        openbsd/olsrd.rcd
 
-SRCS +=		$(wildcard src/bsd/*.c src/unix/*.c)
+SRCS +=		$(sort $(wildcard src/bsd/*.c src/unix/*.c))
 HDRS +=		$(wildcard src/bsd/*.h src/unix/*.h)
 
 CPPFLAGS +=	-D__OpenBSD__

--- a/make/Makefile.osx
+++ b/make/Makefile.osx
@@ -52,7 +52,7 @@ STRIP = \#
 DESTDIR ?=
 LIBDIR =	$(DESTDIR)/usr/lib
 
-SRCS +=		$(wildcard src/bsd/*.c src/unix/*.c src/mach/*.c)
+SRCS +=		$(sort $(wildcard src/bsd/*.c src/unix/*.c src/mach/*.c))
 HDRS +=		$(wildcard src/bsd/*.h src/unix/*.h src/mach/*.h)
 
 LIBS +=		

--- a/make/Makefile.win32
+++ b/make/Makefile.win32
@@ -48,7 +48,7 @@
 DESTDIR ?=
 EXENAME = olsrd.exe
 
-SRCS +=		$(wildcard src/win32/*.c)
+SRCS +=		$(sort $(wildcard src/win32/*.c))
 HDRS +=		$(wildcard src/win32/*.h)
 
 CPPFLAGS += 	-D_WIN32_WINNT=0x0600

--- a/make/Makefile.wince
+++ b/make/Makefile.wince
@@ -48,7 +48,7 @@
 DESTDIR ?=
 LIBDIR =	$(DESTDIR)/usr/lib
 
-SRCS +=		$(wildcard src/win32/*.c)
+SRCS +=		$(sort $(wildcard src/win32/*.c))
 HDRS +=		$(wildcard src/win32/*.h)
 
 CPPFLAGS +=	-DWIN32 -DWINCE

--- a/make/hash_source.sh
+++ b/make/hash_source.sh
@@ -75,15 +75,12 @@ fi
 gitDescriptor="$(git describe --dirty --always 2> /dev/null)"
 
 sourceHash="$(cat $(find . -name *.[ch] | grep -v -E '[/\\]?builddata.c$') | "$md5Command" | awk '{ print $1; }')"
-hostName="$(hostname)"
-buildDate="$(date +"%Y-%m-%d %H:%M:%S")"
 
 tmpBuildDataTxt="$(mktemp -t olsrd.hash_source.XXXXXXXXXX)"
 cat > "$tmpBuildDataTxt" << EOF
 const char olsrd_version[]   = "olsr.org - $version-git_$gitSha-hash_$sourceHash";
 
 const char build_date[]      = "$buildDate";
-const char build_host[]      = "$hostName";
 const char git_descriptor[]  = "$gitDescriptor";
 const char git_sha[]         = "$gitShaFull";
 const char release_version[] = "$version";
@@ -91,20 +88,11 @@ const char source_hash[]     = "$sourceHash";
 EOF
 
 
-if [ ! -e "$buildDataTxt" ]; then
-  echo "[CREATE] $buildDataTxt"
-  if [ "$verbose" = "0" ]; then
-    cp -p "$tmpBuildDataTxt" "$buildDataTxt"
-  else
-    cp -p -v "$tmpBuildDataTxt" "$buildDataTxt"
-  fi
-elif [ -n "$(diff -I "^const char build_date\[\].*\$" "$tmpBuildDataTxt" "$buildDataTxt" | sed 's/"/\\"/g')" ]; then
-  echo "[UPDATE] $buildDataTxt"
-  if [ "$verbose" = "0" ]; then
-    cp -p "$tmpBuildDataTxt" "$buildDataTxt"
-  else
-    cp -p -v "$tmpBuildDataTxt" "$buildDataTxt"
-  fi
+echo "[CREATE] $buildDataTxt"
+if [ "$verbose" = "0" ]; then
+  cp -p "$tmpBuildDataTxt" "$buildDataTxt"
+else
+  cp -p -v "$tmpBuildDataTxt" "$buildDataTxt"
 fi
 rm -f "$tmpBuildDataTxt"
 

--- a/src/builddata.h
+++ b/src/builddata.h
@@ -48,8 +48,6 @@
 
 extern const char olsrd_version[];
 
-extern const char build_date[];
-extern const char build_host[];
 extern const char git_descriptor[];
 extern const char git_sha[];
 extern const char release_version[];

--- a/src/cli.c
+++ b/src/cli.c
@@ -57,8 +57,7 @@ void ListInterfaces(void);
 #endif /* _WIN32 */
 
 void print_version(void) {
-  printf("\n *** %s ***\n Build date: %s on %s\n http://www.olsr.org\n\n",
-      olsrd_version, build_date, build_host);
+  printf("\n *** %s ***\n http://www.olsr.org\n\n", olsrd_version);
 }
 
 /**

--- a/src/olsr.c
+++ b/src/olsr.c
@@ -200,7 +200,7 @@ olsr_process_changes(void)
 
   if (olsr_cnf->debug_level > 0 && olsr_cnf->clear_screen && isatty(1)) {
     clear_console();
-    printf("       *** %s (%s on %s) ***\n", olsrd_version, build_date, build_host);
+    printf("       *** %s ***\n", olsrd_version);
   }
 
   if (changes_neighborhood) {


### PR DESCRIPTION
There are two issues that prevent reproducible building.
- List of source files (which is turned into object files) is not sorted. This causes a random order in which objects are linked.
- The hostname of the build machine and the current date/time are embedded into the binary. As this varies on each build and on every machine, this should be removed.