### PR TITLE
mach: clock_gettime and friends appeared in Mac OSX 10.12

### DIFF
--- a/src/mach/clock_gettime.c
+++ b/src/mach/clock_gettime.c
@@ -45,6 +45,8 @@
 
 #include "clock_gettime.h"
 
+#ifndef CLOCK_MONOTONIC
+
 #include <err.h>
 #include <mach/clock.h>
 #include <mach/mach.h>
@@ -72,3 +74,5 @@ int clock_gettime(clockid_t clock_id, struct timespec *tp) {
 
   return retval;
 }
+
+#endif /* CLOCK_MONOTONIC */

--- a/src/mach/clock_gettime.h
+++ b/src/mach/clock_gettime.h
@@ -50,11 +50,15 @@
 
 #include <time.h>
 
+#ifndef CLOCK_MONOTONIC /* available since OSX 10.12 */
+
 #define CLOCK_MONOTONIC 1	/* Per Linux's time.h */
 typedef int clockid_t; /* Per Linux's types.h, posix_types.h */
 
 /* Per the POSIX Realtime Extensions */
 int clock_gettime(clockid_t clock_id, struct timespec *tp);
+
+#endif /* CLOCK_MONOTONIC */
 
 #endif /* __MACH__ */
 


### PR DESCRIPTION
Since Mac OSX 10.12 `clock_gettime()` is available and the compatibility function should no longer be build.

