### PR TITLE
introduce silent mode (adds 320-silent.patch)

### DIFF
--- a/src/cfgparser/olsrd_conf.c
+++ b/src/cfgparser/olsrd_conf.c
@@ -98,7 +98,8 @@ const char *GW_UPLINK_TXT[] = {
 
 const char *OLSR_IF_MODE[] = {
   "mesh",
-  "ether"
+  "ether",
+  "silent"
 };
 
 int current_line;

--- a/src/cfgparser/oparse.y
+++ b/src/cfgparser/oparse.y
@@ -582,7 +582,7 @@ isetifmode: TOK_IFMODE TOK_STRING
 {
   int ifcnt = ifs_in_curr_cfg;
   struct olsr_if *ifs = olsr_cnf->interfaces;
-	int mode = (strcmp($2->string, "ether") == 0)?IF_MODE_ETHER:IF_MODE_MESH;
+	int mode = (strcmp($2->string, "ether") == 0)?IF_MODE_ETHER:((strcmp($2->string, "silent") == 0)?IF_MODE_SILENT:IF_MODE_MESH);
 
   PARSER_DEBUG_PRINTF("\tMode: %s\n", $2->string);
 

--- a/src/olsr.c
+++ b/src/olsr.c
@@ -378,8 +378,17 @@ olsr_forward_message(union olsr_message *m, struct interface_olsr *in_if, union 
   /* Update packet data */
   msgsize = ntohs(m->v4.olsr_msgsize);
 
+/*!!?? transform tc into delta-tc
+maybe keep track of last change in update_tc_edge, and of last full forward in tc itself (does such object exists?, e.g. check with validity timeout handling)
+first step print out how much data of the tc is irelevant, and maybe skip full messages which are irrelevant (ansn should show that too)
+maybe also count tc's to give info about which nodes have how much flooding packeloss or duplicated, and maybe ansn changes/hour (maybe total and running average of time between 2 ansn)
+*/
+
   /* looping trough interfaces */
   for (ifn = ifnet; ifn; ifn = ifn->int_next) {
+    /* do not retransmit out through a interface if it has mode == silent */
+    if (ifn->mode == IF_MODE_SILENT) continue;
+
     /* do not retransmit out through the same interface if it has mode == ether */
     if (ifn == in_if && ifn->mode == IF_MODE_ETHER) continue;
 

--- a/src/olsr_cfg.h
+++ b/src/olsr_cfg.h
@@ -199,6 +199,7 @@ typedef enum {
 enum olsr_if_mode {
   IF_MODE_MESH,
   IF_MODE_ETHER,
+  IF_MODE_SILENT,
   IF_MODE_CNT
 };
 


### PR DESCRIPTION
if enabled, reduces amount of tc messages. useful for slow links.
olsrd.conf with mode=silent - meant to be used for OpenVPN tunnels.
created by Markus Kittenberger.

Signed-Off-By: Christoph Loesch <mail@chil.at>