### PR TITLE
scheduler: use one, instead of two flags for arranging timers

### DIFF
--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -93,8 +93,7 @@ LISTNODE2STRUCT(list2timer, struct timer_entry, timer_list);
 #define OLSR_TIMER_PERIODIC   1 /* Periodic timer */
 
 /* Timer flags */
-#define OLSR_TIMER_RUNNING  ( 1u << 0)   /* this timer is running */
-#define OLSR_TIMER_REMOVED  ( 1u << 1)   /* this timer is tagged for removal */
+#define OLSR_TIMER_TODO                 (1<<0)
 
 /* Timers */
 void olsr_init_timers(void);


### PR DESCRIPTION
small refactoring of the scheduler.

Authored by Kees-Jan Hermans <hermans@fox-it.com>

Signed-off-by: Iwan G. Flameling <iwanovich@gmail.com>