### PR TITLE
info plugin: remove pointer to timer_entry when stopped

### DIFF
--- a/lib/info/olsrd_info.c
+++ b/lib/info/olsrd_info.c
@@ -408,6 +408,7 @@ static void write_data(void *unused __attribute__((unused))) {
 
   if (!outbuffer.count) {
     olsr_stop_timer(writetimer_entry);
+    writetimer_entry = NULL;
   }
 }
 


### PR DESCRIPTION
Pointers should be removed since timer_entry is eligible for cleanup.

Stopping a timer_entry results in putting it on the cleanup list.
The elements in the cleanup list might be free'd, therefor pointers
to the timer_entry must be removed.

Signed-off-by: Iwan G. Flameling <iwanovich@gmail.com>