### PR TITLE
Feature: Drophna Plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ endif
 cfgparser:	$(CFGDEPS) src/builddata.o
 		$(MAKECMDPREFIX)$(MAKECMD) -C $(CFGDIR)
 
-switch:		
+switch:
 	$(MAKECMDPREFIX)$(MAKECMD) -C $(SWITCHDIR)
 
 # generate it always
@@ -174,12 +174,12 @@ install_olsrd:	install_bin
 		@echo per default.
 		@echo can be found at files/olsrd.conf.default.lq
 		@echo ==========================================================
-		mkdir -p $(ETCDIR)
-		$(MAKECMDPREFIX)if [ -e $(CFGFILE) ]; then \
-			cp -f files/olsrd.conf.default.lq $(CFGFILE).new; \
+		mkdir -p ${TOPDIR}$(ETCDIR)
+		$(MAKECMDPREFIX)if [ -e ${TOPDIR}$(CFGFILE) ]; then \
+			cp -f files/olsrd.conf.default.lq ${TOPDIR}$(CFGFILE).new; \
 			echo "Configuration file was saved as $(CFGFILE).new"; \
 		else \
-			cp -f files/olsrd.conf.default.lq $(CFGFILE); \
+			cp -f files/olsrd.conf.default.lq ${TOPDIR}$(CFGFILE); \
 		fi
 		@echo -------------------------------------------
 		@echo Edit $(CFGFILE) before running olsrd!!

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@
 # Please also write a new version to:
 # gui/win32/Main/Frontend.rc (line 71, around "CAPTION [...]")
 # gui/win32/Inst/installer.nsi (line 57, around "MessageBox MB_YESNO [...]")
-VERS =		0.9.6.2
+VERS =		pre-0.9.7
 
 TOPDIR = $(shell pwd)
 INSTALLOVERWRITE ?=
@@ -62,7 +62,7 @@ endif
 SWITCHDIR =	src/olsr_switch
 CFGDIR =	src/cfgparser
 include $(CFGDIR)/local.mk
-TAG_SRCS =	$(SRCS) $(HDRS) $(wildcard $(CFGDIR)/*.[ch] $(SWITCHDIR)/*.[ch])
+TAG_SRCS =	$(SRCS) $(HDRS) $(sort $(wildcard $(CFGDIR)/*.[ch] $(SWITCHDIR)/*.[ch]))
 
 SGW_SUPPORT = 0
 ifeq ($(OS),linux)
@@ -89,7 +89,7 @@ $(EXENAME):	$(OBJS) $(ANDROIDREGEX) src/builddata.o
 ifeq ($(VERBOSE),0)
 		@echo "[LD] $@"
 endif
-		$(MAKECMDPREFIX)$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
+		$(MAKECMDPREFIX)$(CC) $(LDFLAGS) -lm -o $@ $^ $(LIBS)
 
 cfgparser:	$(CFGDEPS) src/builddata.o
 		$(MAKECMDPREFIX)$(MAKECMD) -C $(CFGDIR)
@@ -224,15 +224,15 @@ rpm:
 
 # This is quite ugly but at least it works
 ifeq ($(OS),linux)
-SUBDIRS := arprefresh bmf dot_draw drophna dyn_gw dyn_gw_plain httpinfo info jsoninfo mdns mini nameservice netjson p2pd pgraph pud quagga secure sgwdynspeed txtinfo watchdog
+SUBDIRS := arprefresh bmf dot_draw drophna dyn_gw dyn_gw_plain httpinfo info jsoninfo mdns mini nameservice netjson poprouting p2pd pgraph pud quagga secure sgwdynspeed txtinfo watchdog
 else
 ifeq ($(OS),win32)
 SUBDIRS := dot_draw httpinfo info jsoninfo mini netjson pgraph secure txtinfo
 else
 ifeq ($(OS),android)
-SUBDIRS := arprefresh bmf dot_draw drophna dyn_gw dyn_gw_plain httpinfo info jsoninfo mdns mini nameservice netjson p2pd pgraph secure sgwdynspeed txtinfo watchdog
+SUBDIRS := arprefresh bmf dot_draw dyn_gw dyn_gw_plain httpinfo info jsoninfo mdns mini nameservice netjson p2pd pgraph secure sgwdynspeed txtinfo watchdog
 else
-SUBDIRS := dot_draw drophna httpinfo info jsoninfo mini nameservice netjson pgraph secure txtinfo watchdog
+SUBDIRS := dot_draw httpinfo info jsoninfo mini nameservice netjson pgraph secure txtinfo watchdog
 endif
 endif
 endif
@@ -314,7 +314,6 @@ drophna_install:
 
 drophna_uninstall:
 	                $(MAKECMDPREFIX)$(MAKECMD) -C lib/drophna DESTDIR=$(DESTDIR) uninstall
-
 
 dyn_gw:
 		$(MAKECMDPREFIX)$(MAKECMD) -C lib/dyn_gw
@@ -422,6 +421,18 @@ netjson_install: info_install
 
 netjson_uninstall: info_uninstall
 		$(MAKECMDPREFIX)$(MAKECMD) -C lib/netjson DESTDIR=$(DESTDIR) uninstall
+
+poprouting: info
+		$(MAKECMDPREFIX)$(MAKECMD) -C lib/poprouting
+
+poprouting_clean: info_clean
+		$(MAKECMDPREFIX)$(MAKECMD) -C lib/poprouting DESTDIR=$(DESTDIR) clean
+
+poprouting_install: info_install
+		$(MAKECMDPREFIX)$(MAKECMD) -C lib/poprouting DESTDIR=$(DESTDIR) install
+
+poprouting_uninstall: info_uninstall
+		$(MAKECMDPREFIX)$(MAKECMD) -C lib/poprouting DESTDIR=$(DESTDIR) uninstall
 
 p2pd:
 		$(MAKECMDPREFIX)$(MAKECMD) -C lib/p2pd

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@
 # Please also write a new version to:
 # gui/win32/Main/Frontend.rc (line 71, around "CAPTION [...]")
 # gui/win32/Inst/installer.nsi (line 57, around "MessageBox MB_YESNO [...]")
-VERS =		pre-0.9.7
+VERS =		0.9.6.2
 
 TOPDIR = $(shell pwd)
 INSTALLOVERWRITE ?=
@@ -62,7 +62,7 @@ endif
 SWITCHDIR =	src/olsr_switch
 CFGDIR =	src/cfgparser
 include $(CFGDIR)/local.mk
-TAG_SRCS =	$(SRCS) $(HDRS) $(sort $(wildcard $(CFGDIR)/*.[ch] $(SWITCHDIR)/*.[ch]))
+TAG_SRCS =	$(SRCS) $(HDRS) $(wildcard $(CFGDIR)/*.[ch] $(SWITCHDIR)/*.[ch])
 
 SGW_SUPPORT = 0
 ifeq ($(OS),linux)
@@ -89,7 +89,7 @@ $(EXENAME):	$(OBJS) $(ANDROIDREGEX) src/builddata.o
 ifeq ($(VERBOSE),0)
 		@echo "[LD] $@"
 endif
-		$(MAKECMDPREFIX)$(CC) $(LDFLAGS) -lm -o $@ $^ $(LIBS)
+		$(MAKECMDPREFIX)$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 cfgparser:	$(CFGDEPS) src/builddata.o
 		$(MAKECMDPREFIX)$(MAKECMD) -C $(CFGDIR)
@@ -224,15 +224,15 @@ rpm:
 
 # This is quite ugly but at least it works
 ifeq ($(OS),linux)
-SUBDIRS := arprefresh bmf dot_draw dyn_gw dyn_gw_plain httpinfo info jsoninfo mdns mini nameservice netjson poprouting p2pd pgraph pud quagga secure sgwdynspeed txtinfo watchdog
+SUBDIRS := arprefresh bmf dot_draw drophna dyn_gw dyn_gw_plain httpinfo info jsoninfo mdns mini nameservice netjson p2pd pgraph pud quagga secure sgwdynspeed txtinfo watchdog
 else
 ifeq ($(OS),win32)
 SUBDIRS := dot_draw httpinfo info jsoninfo mini netjson pgraph secure txtinfo
 else
 ifeq ($(OS),android)
-SUBDIRS := arprefresh bmf dot_draw dyn_gw dyn_gw_plain httpinfo info jsoninfo mdns mini nameservice netjson p2pd pgraph secure sgwdynspeed txtinfo watchdog
+SUBDIRS := arprefresh bmf dot_draw drophna dyn_gw dyn_gw_plain httpinfo info jsoninfo mdns mini nameservice netjson p2pd pgraph secure sgwdynspeed txtinfo watchdog
 else
-SUBDIRS := dot_draw httpinfo info jsoninfo mini nameservice netjson pgraph secure txtinfo watchdog
+SUBDIRS := dot_draw drophna httpinfo info jsoninfo mini nameservice netjson pgraph secure txtinfo watchdog
 endif
 endif
 endif
@@ -302,6 +302,19 @@ dot_draw_install:
 
 dot_draw_uninstall:
 		$(MAKECMDPREFIX)$(MAKECMD) -C lib/dot_draw DESTDIR=$(DESTDIR) uninstall
+
+drophna:
+	                $(MAKECMDPREFIX)$(MAKECMD) -C lib/drophna
+
+drophna_clean:
+	                $(MAKECMDPREFIX)$(MAKECMD) -C lib/drophna DESTDIR=$(DESTDIR) clean
+
+drophna_install:
+	                $(MAKECMDPREFIX)$(MAKECMD) -C lib/drophna DESTDIR=$(DESTDIR) install
+
+drophna_uninstall:
+	                $(MAKECMDPREFIX)$(MAKECMD) -C lib/drophna DESTDIR=$(DESTDIR) uninstall
+
 
 dyn_gw:
 		$(MAKECMDPREFIX)$(MAKECMD) -C lib/dyn_gw
@@ -409,18 +422,6 @@ netjson_install: info_install
 
 netjson_uninstall: info_uninstall
 		$(MAKECMDPREFIX)$(MAKECMD) -C lib/netjson DESTDIR=$(DESTDIR) uninstall
-
-poprouting: info
-		$(MAKECMDPREFIX)$(MAKECMD) -C lib/poprouting
-
-poprouting_clean: info_clean
-		$(MAKECMDPREFIX)$(MAKECMD) -C lib/poprouting DESTDIR=$(DESTDIR) clean
-
-poprouting_install: info_install
-		$(MAKECMDPREFIX)$(MAKECMD) -C lib/poprouting DESTDIR=$(DESTDIR) install
-
-poprouting_uninstall: info_uninstall
-		$(MAKECMDPREFIX)$(MAKECMD) -C lib/poprouting DESTDIR=$(DESTDIR) uninstall
 
 p2pd:
 		$(MAKECMDPREFIX)$(MAKECMD) -C lib/p2pd

--- a/lib/drophna/Makefile
+++ b/lib/drophna/Makefile
@@ -1,0 +1,62 @@
+# The olsr.org Optimized Link-State Routing daemon(olsrd)
+# Copyright (c) 2014, Philipp Borgers <borgers@mi.fu-berlin.de>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in
+#   the documentation and/or other materials provided with the
+#   distribution.
+# * Neither the name of olsr.org, olsrd nor the names of its
+#   contributors may be used to endorse or promote products derived
+#   from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Visit http://www.olsr.org for more information.
+#
+# If you find this software useful feel free to make a donation
+# to the project. For more information see the website or contact
+# the copyright holders.
+#
+
+OLSRD_PLUGIN =	true
+PLUGIN_NAME =	olsrd_drophna
+PLUGIN_VER =	0.0.0
+
+TOPDIR =	../..
+include $(TOPDIR)/Makefile.inc
+
+default_target: $(PLUGIN_FULLNAME)
+
+$(PLUGIN_FULLNAME): $(OBJS) version-script.txt
+ifeq ($(VERBOSE),0)
+		@echo "[LD] $@"
+endif
+		$(MAKECMDPREFIX)$(CC) $(LDFLAGS) -o $(PLUGIN_FULLNAME) $(OBJS) $(LIBS)
+
+install:	$(PLUGIN_FULLNAME)
+		$(STRIP) $(PLUGIN_FULLNAME)
+		$(INSTALL_LIB)
+
+uninstall:
+		$(UNINSTALL_LIB)
+
+clean:
+		rm -f $(OBJS) $(SRCS:%.c=%.d) $(PLUGIN_FULLNAME)

--- a/lib/drophna/README_DROPHNA
+++ b/lib/drophna/README_DROPHNA
@@ -2,14 +2,13 @@
 drophna PLUGIN FOR OLSRD
 ---------------------------------------------------------------------
 
-This plugin is used to remove all gateway (0.0.0.0) HNA's thus 
-preventing internet traffic from traveling through the node.  HNA
-messages are manipulated directly by shortening the message by
-moving the remainder of the message over the gateway announcement.
+This plugin is used to remove all gateway (0.0.0.0) HNA's. HNA
+messages are manipulated directly by moving the remainder of the
+message over the gateway announcement and updating the message size.
 
-An example setup would be a vpn server used to intconnect mesh 
-islands. Routing to all nodes work, but none of the connected 
-islands receive gateway announcemens from another island. 
+An example setup would be a vpn server used to interconnect mesh
+islands. Routing to all nodes work, but none of the connected
+islands receive gateway announcemens from another island.
 
 ---------------------------------------------------------------------
 PLUGIN PARAMETERS (PlParam)

--- a/lib/drophna/README_DROPHNA
+++ b/lib/drophna/README_DROPHNA
@@ -1,0 +1,32 @@
+---------------------------------------------------------------------
+drophna PLUGIN FOR OLSRD
+---------------------------------------------------------------------
+
+This plugin is used to remove all gateway (0.0.0.0) HNA's thus 
+preventing internet traffic from traveling through the node.  HNA
+messages are manipulated directly by shortening the message by
+moving the remainder of the message over the gateway announcement.
+
+An example setup would be a vpn server used to intconnect mesh 
+islands. Routing to all nodes work, but none of the connected 
+islands receive gateway announcemens from another island. 
+
+---------------------------------------------------------------------
+PLUGIN PARAMETERS (PlParam)
+---------------------------------------------------------------------
+
+None.
+
+---------------------------------------------------------------------
+SAMPLE CONFIG
+---------------------------------------------------------------------
+
+add in /etc/olsrd/olsrd.conf:
+
+LoadPlugin "olsrd_drophna.so.0.0.0"
+{
+}
+
+
+---------------------------------------------------------------------
+EOF / 06.05.2018

--- a/lib/drophna/README_DROPHNA
+++ b/lib/drophna/README_DROPHNA
@@ -8,7 +8,7 @@ message over the gateway announcement and updating the message size.
 
 An example setup would be a vpn server used to interconnect mesh
 islands. Routing to all nodes work, but none of the connected
-islands receive gateway announcemens from another island.
+islands receive gateway announcements from another island.
 
 ---------------------------------------------------------------------
 PLUGIN PARAMETERS (PlParam)

--- a/lib/drophna/src/olsrd_drophna.c
+++ b/lib/drophna/src/olsrd_drophna.c
@@ -38,44 +38,6 @@
  *
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <arpa/inet.h>
-#include <sys/types.h>
-#include <netinet/in.h>
-
-/* System includes */
-#include <stddef.h>             /* NULL */
-#include <sys/types.h>          /* ssize_t */
-#include <string.h>             /* strerror() */
-#include <stdarg.h>             /* va_list, va_start, va_end */
-#include <errno.h>              /* errno */
-#include <assert.h>             /* assert() */
-#include <unistd.h>
-#include <fcntl.h>
-#include <linux/if_ether.h>     /* ETH_P_IP */
-#include <linux/if_packet.h>    /* struct sockaddr_ll, PACKET_MULTICAST */
-#include <signal.h>             /* sigset_t, sigfillset(), sigdelset(), SIGINT */
-#include <netinet/ip.h>         /* struct ip */
-#include <netinet/udp.h>        /* struct udphdr */
-#include <unistd.h>             /* close() */
-
-#include <netinet/in.h>
-#include <netinet/ip6.h>
-
-#include <time.h>
-
-/* OLSRD includes */
-#include "plugin_util.h"        /* set_plugin_int */
-#include "defs.h"               /* olsr_cnf, //OLSR_PRINTF */
-#include "ipcalc.h"
-#include "olsr.h"               /* //OLSR_PRINTF */
-#include "mid_set.h"            /* mid_lookup_main_addr() */
-#include "link_set.h"           /* get_best_link_to_neighbor() */
-#include "net_olsr.h"           /* ipequal */
-#include "parser.h"
-
 #include "olsrd_drophna.h"
 
 /* -------------------------------------------------------------------------

--- a/lib/drophna/src/olsrd_drophna.c
+++ b/lib/drophna/src/olsrd_drophna.c
@@ -78,10 +78,6 @@
 
 #include "olsrd_drophna.h"
 
-
-char * get_ipv4_str(uint32_t address, char *s, size_t maxlen);
-char * get_ipv6_str(unsigned char* address, char *s, size_t maxlen);
-
 /* -------------------------------------------------------------------------
  * Function   : olsr_blacklist_parser
  * Description: Function to be passed to the parser engine. This function
@@ -182,48 +178,6 @@ olsrd_drophna_parser(
     }
   }
 	return true;
-}
-
-/* -------------------------------------------------------------------------
- * Function   : get_ipv4_str
- * Description: Convert the specified address to an IPv4 compatible string
- * Input      : address - IPv4 address to convert to string
- *              s       - string buffer to contain the resulting string
- *              maxlen  - maximum length of the string buffer
- * Output     : none
- * Return     : Pointer to the string buffer containing the result
- * Data Used  : none
- * ------------------------------------------------------------------------- */
-char *
-get_ipv4_str(uint32_t address, char *s, size_t maxlen)
-{
-  struct sockaddr_in v4;
-
-  v4.sin_addr.s_addr = address;
-  inet_ntop(AF_INET, &v4.sin_addr, s, maxlen);
-
-  return s;
-}
-
-/* -------------------------------------------------------------------------
- * Function   : get_ipv6_str
- * Description: Convert the specified address to an IPv4 compatible string
- * Input      : address - IPv6 address to convert to string
- *              s       - string buffer to contain the resulting string
- *              maxlen  - maximum length of the string buffer
- * Output     : none
- * Return     : Pointer to the string buffer containing the result
- * Data Used  : none
- * ------------------------------------------------------------------------- */
-char *
-get_ipv6_str(unsigned char* address, char *s, size_t maxlen)
-{
-  struct sockaddr_in6 v6;
-
-  memcpy(v6.sin6_addr.s6_addr, address, sizeof(v6.sin6_addr.s6_addr));
-  inet_ntop(AF_INET6, &v6.sin6_addr, s, maxlen);
-
-  return s;
 }
 
 void olsrd_drophna_init() {

--- a/lib/drophna/src/olsrd_drophna.c
+++ b/lib/drophna/src/olsrd_drophna.c
@@ -1,0 +1,230 @@
+/*
+ * The olsr.org Optimized Link-State Routing daemon(olsrd)
+ * Copyright (c) 2004-2009, the olsr.org team - see HISTORY file
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ * * Neither the name of olsr.org, olsrd nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Visit http://www.olsr.org for more information.
+ *
+ * If you find this software useful feel free to make a donation
+ * to the project. For more information see the website or contact
+ * the copyright holders.
+ *
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <arpa/inet.h>
+#include <sys/types.h>
+#include <netinet/in.h>
+
+/* System includes */
+#include <stddef.h>             /* NULL */
+#include <sys/types.h>          /* ssize_t */
+#include <string.h>             /* strerror() */
+#include <stdarg.h>             /* va_list, va_start, va_end */
+#include <errno.h>              /* errno */
+#include <assert.h>             /* assert() */
+#include <unistd.h>
+#include <fcntl.h>
+#include <linux/if_ether.h>     /* ETH_P_IP */
+#include <linux/if_packet.h>    /* struct sockaddr_ll, PACKET_MULTICAST */
+#include <signal.h>             /* sigset_t, sigfillset(), sigdelset(), SIGINT */
+#include <netinet/ip.h>         /* struct ip */
+#include <netinet/udp.h>        /* struct udphdr */
+#include <unistd.h>             /* close() */
+
+#include <netinet/in.h>
+#include <netinet/ip6.h>
+
+#include <time.h>
+
+/* OLSRD includes */
+#include "plugin_util.h"        /* set_plugin_int */
+#include "defs.h"               /* olsr_cnf, //OLSR_PRINTF */
+#include "ipcalc.h"
+#include "olsr.h"               /* //OLSR_PRINTF */
+#include "mid_set.h"            /* mid_lookup_main_addr() */
+#include "link_set.h"           /* get_best_link_to_neighbor() */
+#include "net_olsr.h"           /* ipequal */
+#include "parser.h"
+
+#include "olsrd_drophna.h"
+
+
+char * get_ipv4_str(uint32_t address, char *s, size_t maxlen);
+char * get_ipv6_str(unsigned char* address, char *s, size_t maxlen);
+
+/* -------------------------------------------------------------------------
+ * Function   : olsr_blacklist_parser
+ * Description: Function to be passed to the parser engine. This function
+ *              processes the incoming message and passes it on if necessary.
+ * Input      : m      - message to parse
+ *              in_if  - interface to use (unused in this application)
+ *              ipaddr - IP-address to use (unused in this application)
+ * Output     : none
+ * Return     : false if message should be supressed, true otherwise
+ * Data Used  : none
+ * ------------------------------------------------------------------------- */
+bool
+olsrd_drophna_parser(
+    union olsr_message *m,
+    struct interface *in_if __attribute__ ((unused)),
+    union olsr_ip_addr *ipaddr __attribute__ ((unused))
+){
+
+  uint8_t olsr_msgtype;
+  olsr_reltime vtime;
+  uint16_t olsr_msgsize;
+  union olsr_ip_addr originator;
+  uint8_t hop_count;
+  uint16_t msg_seq_number;
+
+  int hnasize;
+  const uint8_t *curr, *curr_end;
+
+  struct ipaddr_str buf;
+#ifdef DEBUG
+  OLSR_PRINTF(5, "Processing HNA\n");
+#endif
+
+  /* Check if everyting is ok */
+  if (!m) {
+    return false;
+  }
+  curr = (const uint8_t *)m;
+
+  /* olsr_msgtype */
+  pkt_get_u8(&curr, &olsr_msgtype);
+  if (olsr_msgtype != HNA_MESSAGE) {
+    OLSR_PRINTF(1, "not a HNA message!\n");
+    return false;
+  }
+  /* Get vtime */
+  pkt_get_reltime(&curr, &vtime);
+
+  /* olsr_msgsize */
+  pkt_get_u16(&curr, &olsr_msgsize);
+
+  hnasize = olsr_msgsize - 8 - olsr_cnf->ipsize;
+  curr_end = (const uint8_t *)m + olsr_msgsize;
+
+  /* validate originator */
+  pkt_get_ipaddress(&curr, &originator);
+  /*printf("HNA from %s\n\n", olsr_ip_to_string(&buf, &originator)); */
+
+  /* ttl */
+  pkt_ignore_u8(&curr);
+
+  /* hopcnt */
+  pkt_get_u8(&curr, &hop_count);
+
+  /* seqno */
+  pkt_get_u16(&curr, &msg_seq_number);
+
+  if ((hnasize % (2 * olsr_cnf->ipsize)) != 0) {
+    OLSR_PRINTF(1, "Illegal HNA message from %s with size %d!\n",
+        olsr_ip_to_string(&buf, &originator), olsr_msgsize);
+    return false;
+  }
+
+  while (curr < curr_end) {
+    struct olsr_ip_prefix prefix;
+    union olsr_ip_addr mask;
+
+    pkt_get_ipaddress(&curr, &prefix.prefix);
+    pkt_get_ipaddress(&curr, &mask);
+    prefix.prefix_len = olsr_netmask_to_prefix(&mask);
+
+    if (is_prefix_inetgw(&prefix)) {
+        hnasize -= 2 * olsr_cnf->ipsize;
+        if (0 < hnasize) {
+            uint8_t *dest = curr - 2 * olsr_cnf->ipsize;
+            memmove(dest, curr, curr_end - curr);
+            curr_end -= 2 * olsr_cnf->ipsize;
+            curr = dest;
+            if (olsr_cnf->ip_version == AF_INET) {
+                m->v4.olsr_msgsize -= 2 * olsr_cnf->ipsize;
+            }
+            else {
+                m->v6.olsr_msgsize -= 2 * olsr_cnf->ipsize;
+            }
+            continue;
+        }
+        return false;
+    }
+  }
+	return true;
+}
+
+/* -------------------------------------------------------------------------
+ * Function   : get_ipv4_str
+ * Description: Convert the specified address to an IPv4 compatible string
+ * Input      : address - IPv4 address to convert to string
+ *              s       - string buffer to contain the resulting string
+ *              maxlen  - maximum length of the string buffer
+ * Output     : none
+ * Return     : Pointer to the string buffer containing the result
+ * Data Used  : none
+ * ------------------------------------------------------------------------- */
+char *
+get_ipv4_str(uint32_t address, char *s, size_t maxlen)
+{
+  struct sockaddr_in v4;
+
+  v4.sin_addr.s_addr = address;
+  inet_ntop(AF_INET, &v4.sin_addr, s, maxlen);
+
+  return s;
+}
+
+/* -------------------------------------------------------------------------
+ * Function   : get_ipv6_str
+ * Description: Convert the specified address to an IPv4 compatible string
+ * Input      : address - IPv6 address to convert to string
+ *              s       - string buffer to contain the resulting string
+ *              maxlen  - maximum length of the string buffer
+ * Output     : none
+ * Return     : Pointer to the string buffer containing the result
+ * Data Used  : none
+ * ------------------------------------------------------------------------- */
+char *
+get_ipv6_str(unsigned char* address, char *s, size_t maxlen)
+{
+  struct sockaddr_in6 v6;
+
+  memcpy(v6.sin6_addr.s6_addr, address, sizeof(v6.sin6_addr.s6_addr));
+  inet_ntop(AF_INET6, &v6.sin6_addr, s, maxlen);
+
+  return s;
+}
+
+void olsrd_drophna_init() {
+}

--- a/lib/drophna/src/olsrd_drophna.h
+++ b/lib/drophna/src/olsrd_drophna.h
@@ -52,8 +52,10 @@
 #define MOD_DESC PLUGIN_NAME      " " PLUGIN_VERSION
 #define PLUGIN_INTERFACE_VERSION  5
 
-void olsrd_drophna_init();
-
+void olsrd_drophna_init(void);
+bool olsrd_drophna_parser(union olsr_message *m,
+		struct interface_olsr *in_if,
+		union olsr_ip_addr *ipaddr);
 
 
 #endif /* _DROPHNA_H*/

--- a/lib/drophna/src/olsrd_drophna.h
+++ b/lib/drophna/src/olsrd_drophna.h
@@ -42,8 +42,7 @@
 #ifndef LIB_DROPHNA_SRC_OLSRD_DROPHNA_H_
 #define LIB_DROPHNA_SRC_OLSRD_DROPHNA_H_
 
-#include "olsr_types.h"
-#include "lq_packet.h"
+#include "link_set.h"
 
 void olsrd_drophna_init(void);
 bool olsrd_drophna_parser(union olsr_message *m,

--- a/lib/drophna/src/olsrd_drophna.h
+++ b/lib/drophna/src/olsrd_drophna.h
@@ -39,8 +39,8 @@
  */
 
 
-#ifndef _BLACKLIST_H
-#define _BLACKLIST_H
+#ifndef _DROPHNA_H
+#define _DROPHNA_H
 
 #include "olsr_types.h" //for the fucking bool
 #include "lq_packet.h"
@@ -54,15 +54,9 @@
 
 void olsrd_drophna_init();
 
-/* Parser function to register with the scheduler */
-bool olsrd_blacklist_parser(
-    union olsr_message *,
-    struct interface *,
-    union olsr_ip_addr *
-    );
 
 
-#endif /* _BLACKLIST_H */
+#endif /* _DROPHNA_H*/
 
 /*
  * Local Variables:

--- a/lib/drophna/src/olsrd_drophna.h
+++ b/lib/drophna/src/olsrd_drophna.h
@@ -1,0 +1,72 @@
+/*
+ * The olsr.org Optimized Link-State Routing daemon(olsrd)
+ * Copyright (c) 2004-2009, the olsr.org team - see HISTORY file
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ * * Neither the name of olsr.org, olsrd nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Visit http://www.olsr.org for more information.
+ *
+ * If you find this software useful feel free to make a donation
+ * to the project. For more information see the website or contact
+ * the copyright holders.
+ *
+ */
+
+
+#ifndef _BLACKLIST_H
+#define _BLACKLIST_H
+
+#include "olsr_types.h" //for the fucking bool
+#include "lq_packet.h"
+
+/* BLACKLIST plugin data */
+#define PLUGIN_NAME               "OLSRD drophna plugin"
+#define PLUGIN_NAME_SHORT         "OLSRD drophna"
+#define PLUGIN_VERSION            "0.0.0 (" __DATE__ " " __TIME__ ")"
+#define MOD_DESC PLUGIN_NAME      " " PLUGIN_VERSION
+#define PLUGIN_INTERFACE_VERSION  5
+
+void olsrd_drophna_init();
+
+/* Parser function to register with the scheduler */
+bool olsrd_blacklist_parser(
+    union olsr_message *,
+    struct interface *,
+    union olsr_ip_addr *
+    );
+
+
+#endif /* _BLACKLIST_H */
+
+/*
+ * Local Variables:
+ * c-basic-offset: 2
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/lib/drophna/src/olsrd_drophna.h
+++ b/lib/drophna/src/olsrd_drophna.h
@@ -39,18 +39,11 @@
  */
 
 
-#ifndef _DROPHNA_H
-#define _DROPHNA_H
+#ifndef LIB_DROPHNA_SRC_OLSRD_DROPHNA_H_
+#define LIB_DROPHNA_SRC_OLSRD_DROPHNA_H_
 
-#include "olsr_types.h" //for the fucking bool
+#include "olsr_types.h"
 #include "lq_packet.h"
-
-/* BLACKLIST plugin data */
-#define PLUGIN_NAME               "OLSRD drophna plugin"
-#define PLUGIN_NAME_SHORT         "OLSRD drophna"
-#define PLUGIN_VERSION            "0.0.0 (" __DATE__ " " __TIME__ ")"
-#define MOD_DESC PLUGIN_NAME      " " PLUGIN_VERSION
-#define PLUGIN_INTERFACE_VERSION  5
 
 void olsrd_drophna_init(void);
 bool olsrd_drophna_parser(union olsr_message *m,
@@ -58,7 +51,7 @@ bool olsrd_drophna_parser(union olsr_message *m,
 		union olsr_ip_addr *ipaddr);
 
 
-#endif /* _DROPHNA_H*/
+#endif /* LIB_DROPHNA_SRC_OLSRD_DROPHNA_H_ */
 
 /*
  * Local Variables:

--- a/lib/drophna/src/olsrd_plugin.c
+++ b/lib/drophna/src/olsrd_plugin.c
@@ -46,11 +46,15 @@
 #include "olsrd_plugin.h"
 #include "defs.h"
 #include "olsrd_drophna.h"
+#include "parser.h"
+
+static void my_init(void) __attribute__ ((constructor));
+static void my_fini(void) __attribute__ ((destructor));
 
 /* Parser function to register with the scheduler */
 bool olsrd_drophna_parser(
     union olsr_message *,
-    struct interface *,
+    struct interface_olsr *,
     union olsr_ip_addr *
     );
 
@@ -58,6 +62,7 @@ int olsrd_plugin_init(void) {
   olsr_parser_add_function(&olsrd_drophna_parser, HNA_MESSAGE);
   return 0;
 }
+void olsr_plugin_exit(void);
 void olsr_plugin_exit(void) {}
 
 /**

--- a/lib/drophna/src/olsrd_plugin.c
+++ b/lib/drophna/src/olsrd_plugin.c
@@ -1,0 +1,108 @@
+
+/*
+ * The olsr.org Optimized Link-State Routing daemon(olsrd)
+ * Copyright (c) 2004, Andreas Tonnesen(andreto@olsr.org)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ * * Neither the name of olsr.org, olsrd nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Visit http://www.olsr.org for more information.
+ *
+ * If you find this software useful feel free to make a donation
+ * to the project. For more information see the website or contact
+ * the copyright holders.
+ *
+ */
+
+/*
+ * Dynamic linked library for the olsr.org olsr daemon
+ */
+
+#include "olsrd_plugin.h"
+#include "defs.h"
+#include "olsrd_drophna.h"
+
+int olsrd_plugin_init(void) {
+  olsr_parser_add_function(&olsrd_blacklist_parser, HELLO_MESSAGE);
+  olsr_parser_add_function(&olsrd_blacklist_parser, LQ_HELLO_MESSAGE);
+  fprintf(stderr, "foobarbaz\n");
+  return 0;
+}
+void olsr_plugin_exit(void) {}
+
+/**
+ *Constructor
+ */
+static void
+my_init(void)
+{
+  /* Print plugin info to stdout */
+  fprintf(stderr, "fuz");
+  printf("%s\n", MOD_DESC);
+  //olsrd_blacklist_init();
+}
+
+/**
+ *Destructor
+ */
+static void
+my_fini(void)
+{
+  /* Calls the destruction function
+   * olsr_plugin_exit()
+   * This function should be present in your
+   * sourcefile and all data destruction
+   * should happen there - NOT HERE!
+   */
+  olsr_plugin_exit();
+}
+
+int
+olsrd_plugin_interface_version(void)
+{
+  return PLUGIN_INTERFACE_VERSION;
+}
+
+static const struct olsrd_plugin_parameters plugin_parameters[] = {
+};
+
+void
+olsrd_get_plugin_parameters(const struct olsrd_plugin_parameters **params, int *size)
+{
+  *params = plugin_parameters;
+  *size = sizeof(plugin_parameters) / sizeof(*plugin_parameters);
+}
+
+/*
+ * Local Variables:
+ * mode: c
+ * style: linux
+ * c-basic-offset: 2
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/lib/drophna/src/olsrd_plugin.c
+++ b/lib/drophna/src/olsrd_plugin.c
@@ -47,10 +47,15 @@
 #include "defs.h"
 #include "olsrd_drophna.h"
 
+/* Parser function to register with the scheduler */
+bool olsrd_drophna_parser(
+    union olsr_message *,
+    struct interface *,
+    union olsr_ip_addr *
+    );
+
 int olsrd_plugin_init(void) {
-  olsr_parser_add_function(&olsrd_blacklist_parser, HELLO_MESSAGE);
-  olsr_parser_add_function(&olsrd_blacklist_parser, LQ_HELLO_MESSAGE);
-  fprintf(stderr, "foobarbaz\n");
+  olsr_parser_add_function(&olsrd_drophna_parser, HNA_MESSAGE);
   return 0;
 }
 void olsr_plugin_exit(void) {}
@@ -62,7 +67,6 @@ static void
 my_init(void)
 {
   /* Print plugin info to stdout */
-  fprintf(stderr, "fuz");
   printf("%s\n", MOD_DESC);
   //olsrd_blacklist_init();
 }

--- a/lib/drophna/src/olsrd_plugin.c
+++ b/lib/drophna/src/olsrd_plugin.c
@@ -44,9 +44,6 @@
  */
 
 #include "olsrd_plugin.h"
-#include "plugin_util.h"
-#include "olsr.h"
-#include "defs.h"
 #include "olsrd_drophna.h"
 #include "parser.h"
 #include "builddata.h"

--- a/lib/drophna/src/olsrd_plugin.h
+++ b/lib/drophna/src/olsrd_plugin.h
@@ -1,7 +1,11 @@
-
 /*
- * The olsr.org Optimized Link-State Routing daemon(olsrd)
- * Copyright (c) 2004, Andreas Tonnesen(andreto@olsr.org)
+ * The olsr.org Optimized Link-State Routing daemon (olsrd)
+ *
+ * (c) by the OLSR project
+ *
+ * See our Git repository to find out who worked on this file
+ * and thus is a copyright holder on it.
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -43,87 +47,20 @@
  * Dynamic linked library for the olsr.org olsr daemon
  */
 
-#include "olsrd_plugin.h"
+#ifndef LIB_DROPHNA_SRC_OLSRD_PLUGIN_H_
+#define LIB_DROPHNA_SRC_OLSRD_PLUGIN_H_
+
 #include "plugin_util.h"
-#include "olsr.h"
-#include "defs.h"
-#include "olsrd_drophna.h"
-#include "parser.h"
-#include "builddata.h"
 
-#define PLUGIN_NAME              "DROPHNA"
-#define PLUGIN_TITLE             "OLSRD drophna plugin"
-#define PLUGIN_INTERFACE_VERSION 5
+int olsrd_plugin_interface_version(void);
+int olsrd_plugin_init(void);
+void olsr_plugin_exit(void);
+void olsrd_get_plugin_parameters(const struct olsrd_plugin_parameters **params, int *size);
 
-static void my_init(void) __attribute__ ((constructor));
-static void my_fini(void) __attribute__ ((destructor));
-
-/**
- *Constructor
- */
-static void
-my_init(void)
-{
-  /* Print plugin info to stdout */
-  OLSR_PRINTF(0, "%s (%s)\n", PLUGIN_NAME, git_descriptor);
-}
-
-/**
- *Destructor
- */
-static void
-my_fini(void)
-{
-  /* Calls the destruction function
-   * olsr_plugin_exit()
-   * This function should be present in your
-   * sourcefile and all data destruction
-   * should happen there - NOT HERE!
-   */
-  olsr_plugin_exit();
-}
-
-/**
- *Do initialization here
- *
- *This function is called by the my_init
- *function in uolsrd_plugin.c
- */
-int olsrd_plugin_init(void) {
-  olsr_parser_add_function(&olsrd_drophna_parser, HNA_MESSAGE);
-  return 0;
-}
-
-/**
- * destructor - called at unload
- */
-void olsr_plugin_exit(void) {
-}
-
-static const struct olsrd_plugin_parameters plugin_parameters[] = {
-};
-
-/**
- * Plugin interface version
- * Used by main olsrd to check plugin interface version
- */
-int
-olsrd_plugin_interface_version(void)
-{
-  return PLUGIN_INTERFACE_VERSION;
-}
-
-void
-olsrd_get_plugin_parameters(const struct olsrd_plugin_parameters **params, int *size)
-{
-  *params = plugin_parameters;
-  *size = sizeof(plugin_parameters) / sizeof(*plugin_parameters);
-}
+#endif /* LIB_DROPHNA_SRC_OLSRD_PLUGIN_H_ */
 
 /*
  * Local Variables:
- * mode: c
- * style: linux
  * c-basic-offset: 2
  * indent-tabs-mode: nil
  * End:

--- a/lib/drophna/version-script.txt
+++ b/lib/drophna/version-script.txt
@@ -1,0 +1,11 @@
+VERS_1.0
+{
+  global:
+    olsrd_plugin_interface_version;
+    olsrd_plugin_init;
+    olsrd_get_plugin_parameters;
+
+  local:
+    *;
+};
+

--- a/lib/pud/Makefile
+++ b/lib/pud/Makefile
@@ -125,8 +125,8 @@ install: all
 	$(MAKECMDPREFIX)$(MAKE) -C "$(NMEALIB_PATH)" DESTDIR="$(DESTDIR)" install
 	$(MAKECMDPREFIX)$(MAKE) -C "$(LIBRARY_PATH)" DESTDIR="$(DESTDIR)" install
 	$(INSTALL_LIB)
-	mkdir -p "$(ETCDIR)"
-	cp "$(RESOURCESDIR)/olsrd.pud.position.conf" "$(ETCDIR)"
+	mkdir -p "${TOPDIR}$(ETCDIR)"
+	cp "$(RESOURCESDIR)/olsrd.pud.position.conf" "${TOPDIR}$(ETCDIR)"
 	$(STRIP) "$(LIBDIR)/$(PLUGIN_FULLNAME)"
 
 uninstall:

--- a/lib/sgwdynspeed/Makefile
+++ b/lib/sgwdynspeed/Makefile
@@ -85,8 +85,8 @@ endif
 
 install: all
 	$(INSTALL_LIB)
-	mkdir -p "$(ETCDIR)"
-	cp "$(RESOURCESDIR)/olsrd.sgw.speed.conf" "$(ETCDIR)"
+	mkdir -p "${TOPDIR}$(ETCDIR)"
+	cp "$(RESOURCESDIR)/olsrd.sgw.speed.conf" "${TOPDIR}$(ETCDIR)"
 	$(STRIP) "$(LIBDIR)/$(PLUGIN_FULLNAME)"
 
 uninstall:


### PR DESCRIPTION
This plugin is used to remove all gateway (0.0.0.0) HNA's. HNA messages are manipulated directly by moving the remainder of the message over the gateway announcement and updating the message size.

An example setup would be a vpn server used to interconnect mesh islands. Routing to all nodes work, but none of the connected islands receive gateway announcements from another island.

This is a better cleaner pull request than the last one.