### PR TITLE
routing: remove rt_entry.rt_best pointer when rt_path is deleted

### DIFF
--- a/src/routing_table.c
+++ b/src/routing_table.c
@@ -352,6 +352,7 @@ olsr_insert_rt_path(struct rt_path *rtp, struct tc_entry *tc, struct link_entry 
 void
 olsr_delete_rt_path(struct rt_path *rtp)
 {
+  struct rt_entry* rt;
 
   /* remove from the originator tree */
   if (rtp->rtp_rt) {
@@ -372,9 +373,8 @@ olsr_delete_rt_path(struct rt_path *rtp)
   }
 
   /* remove reference from rt_best */
-  struct rt_entry* rt;
   OLSR_FOR_ALL_RT_ENTRIES(rt)
-  if(rt->rt_best == rtp){
+  if (rt->rt_best == rtp){
     rt->rt_best = NULL;
     OLSR_PRINTF(7, "Removed rt_best.\n");
   }

--- a/src/routing_table.c
+++ b/src/routing_table.c
@@ -371,6 +371,15 @@ olsr_delete_rt_path(struct rt_path *rtp)
     current_inetgw = NULL;
   }
 
+  /* remove reference from rt_best */
+  struct rt_entry* rt;
+  OLSR_FOR_ALL_RT_ENTRIES(rt)
+  if(rt->rt_best == rtp){
+    rt->rt_best = NULL;
+    OLSR_PRINTF(7, "Removed rt_best.\n");
+  }
+  OLSR_FOR_ALL_RT_ENTRIES_END(rt)
+
   olsr_cookie_free(rtp_mem_cookie, rtp);
 }
 


### PR DESCRIPTION
When rt_path is free'd from memory, references to it should be deleted.

Checking all rt_entry structs for rt_best pointers to the rt_path
that is to be deleted and nullify the pointer. Not doing so might
lead to segfaults.

Signed-off-by: Iwan G. Flameling <iwanovich@gmail.com>