### PR TITLE
Fix Makefiles not to create files in root dir when building packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ endif
 cfgparser:	$(CFGDEPS) src/builddata.o
 		$(MAKECMDPREFIX)$(MAKECMD) -C $(CFGDIR)
 
-switch:		
+switch:
 	$(MAKECMDPREFIX)$(MAKECMD) -C $(SWITCHDIR)
 
 # generate it always
@@ -174,12 +174,12 @@ install_olsrd:	install_bin
 		@echo per default.
 		@echo can be found at files/olsrd.conf.default.lq
 		@echo ==========================================================
-		mkdir -p $(ETCDIR)
-		$(MAKECMDPREFIX)if [ -e $(CFGFILE) ]; then \
-			cp -f files/olsrd.conf.default.lq $(CFGFILE).new; \
+		mkdir -p ${TOPDIR}$(ETCDIR)
+		$(MAKECMDPREFIX)if [ -e ${TOPDIR}$(CFGFILE) ]; then \
+			cp -f files/olsrd.conf.default.lq ${TOPDIR}$(CFGFILE).new; \
 			echo "Configuration file was saved as $(CFGFILE).new"; \
 		else \
-			cp -f files/olsrd.conf.default.lq $(CFGFILE); \
+			cp -f files/olsrd.conf.default.lq ${TOPDIR}$(CFGFILE); \
 		fi
 		@echo -------------------------------------------
 		@echo Edit $(CFGFILE) before running olsrd!!

--- a/lib/pud/Makefile
+++ b/lib/pud/Makefile
@@ -125,8 +125,8 @@ install: all
 	$(MAKECMDPREFIX)$(MAKE) -C "$(NMEALIB_PATH)" DESTDIR="$(DESTDIR)" install
 	$(MAKECMDPREFIX)$(MAKE) -C "$(LIBRARY_PATH)" DESTDIR="$(DESTDIR)" install
 	$(INSTALL_LIB)
-	mkdir -p "$(ETCDIR)"
-	cp "$(RESOURCESDIR)/olsrd.pud.position.conf" "$(ETCDIR)"
+	mkdir -p "${TOPDIR}$(ETCDIR)"
+	cp "$(RESOURCESDIR)/olsrd.pud.position.conf" "${TOPDIR}$(ETCDIR)"
 	$(STRIP) "$(LIBDIR)/$(PLUGIN_FULLNAME)"
 
 uninstall:

--- a/lib/sgwdynspeed/Makefile
+++ b/lib/sgwdynspeed/Makefile
@@ -85,8 +85,8 @@ endif
 
 install: all
 	$(INSTALL_LIB)
-	mkdir -p "$(ETCDIR)"
-	cp "$(RESOURCESDIR)/olsrd.sgw.speed.conf" "$(ETCDIR)"
+	mkdir -p "${TOPDIR}$(ETCDIR)"
+	cp "$(RESOURCESDIR)/olsrd.sgw.speed.conf" "${TOPDIR}$(ETCDIR)"
 	$(STRIP) "$(LIBDIR)/$(PLUGIN_FULLNAME)"
 
 uninstall:


### PR DESCRIPTION
When building debian packages, files get installed in root dir instead of build dir, thus permission denied error occurs on building process. Change to install files in build dir on building to fix this.