### PR TITLE
README-Debian-package: Update build instructions

### DIFF
--- a/README-Debian-package
+++ b/README-Debian-package
@@ -2,14 +2,18 @@
 If you want to build the Debian packages from the latest git source, here is
 how to do it:
 
-First, get the latest debian/ folder from Subversion, which contains all the
-files needed to build the Debian package, then run dpkg-buildpackage:
+First, get the latest debian/ folder from salsa.debian.org, which contains
+all the files needed to build the Debian package, then run dpkg-buildpackage:
 
   sudo apt-get install build-essential dpkg-dev
-  git clone https://github.com/OLSR/olsrd.git
+  git clone <url to olsrd repo>
   cd olsrd
-  svn checkout svn://svn.debian.org/svn/collab-maint/deb-maint/olsrd/trunk/debian
+  git checkout <your feature branch> # This step is optional
+  git remote add debbuild https://salsa.debian.org/debian/olsrd.git 
+  git fetch debbuild
+  git checkout debbuild/master debian
   echo "1.0" > debian/source/format
+  vi debian/changelog # Set the version number on top line (optional)
   dpkg-buildpackage -uc -us
   ls -l ../olsrd*.*
 


### PR DESCRIPTION
Update the build instructions to use the maintained debian catalog.

This addresses issue #64 

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>