### PR TITLE
lib/pud/Makefile: fix parallel build

### DIFF
--- a/lib/pud/Makefile
+++ b/lib/pud/Makefile
@@ -108,7 +108,7 @@ endif
 
 default_target: nmealib library $(PLUGIN_FULLNAME)
 
-$(PLUGIN_FULLNAME): $(OBJS) version-script.txt
+$(PLUGIN_FULLNAME): $(OBJS) version-script.txt nmealib
 ifeq ($(PUD_NMEALIB_STATICALLY_LINKED),)
 ifeq ($(VERBOSE),0)
 	@echo "[LD] $@ (nmealib dynamically linked)"


### PR DESCRIPTION
nmealib is needed to build olsrd_pud plugin otherwise build fails on:

[LD] olsrd_pud.so.3.0.0 (nmealib dynamically linked)
/home/fabrice/buildroot/output/host/opt/ext-toolchain/bin/../lib/gcc/arm-none-linux-gnueabi/4.8.3/../../../../arm-none-linux-gnueabi/bin/ld: cannot find -lnmea
wireformat/lib/libOlsrdPudWireFormat.so: file not recognized: File truncated

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>