### PR TITLE
pud: adapt to API changes in gpsd 3.20

### DIFF
--- a/lib/pud/src/gpsdclient.c
+++ b/lib/pud/src/gpsdclient.c
@@ -79,6 +79,23 @@ static void gpsdError(const char *s) {
   syslog(LOG_ERR, "gpsd error: %s", s);
 }
 
+#if GPSD_API_MAJOR_VERSION >= 9
+static double time_as_double(struct timespec *ts) {
+ return (ts->tv_sec + ts->tv_nsec * 1e-9);
+}
+
+static bool is_online(struct gps_data_t *gpsdata) {
+  return !!gpsdata->online.tv_sec;
+}
+#else
+
+#define time_as_double(x) *(x)
+
+static bool is_online(struct gps_data_t *gpsdata) {
+  return !!gpsdata->online;
+}
+#endif
+
 /* standard parsing of a GPS data source spec */
 void gpsdParseSourceSpec(char *arg, GpsDaemon *gpsDaemon) {
   if (!arg //
@@ -298,8 +315,8 @@ void nmeaInfoFromGpsd(struct gps_data_t *gpsdata, NmeaInfo *info, struct GpsdCon
             8, //
             dev->parity, //
             dev->stopbits, //
-            dev->cycle, //
-            dev->mincycle);
+            time_as_double(&dev->cycle), //
+            time_as_double(&dev->mincycle));
 
         connectionTracking->devSeen[i] = true;
         connectionTracking->dev[i] = *dev;
@@ -367,11 +384,18 @@ void nmeaInfoFromGpsd(struct gps_data_t *gpsdata, NmeaInfo *info, struct GpsdCon
   nmeaInfoSetPresent(&info->present, NMEALIB_PRESENT_SMASK);
 
   /* date & time */
+#if GPSD_API_MAJOR_VERSION >= 9
+  if (gpsdata->fix.time.tv_sec > 0) {
+    struct tm *time = gmtime(&gpsdata->fix.time.tv_sec);
+    unsigned int hsec = (unsigned int) (gpsdata->fix.time.tv_nsec / 10000000);
+#else
   if (!isNaN(gpsdata->fix.time)) {
     double seconds;
     double fraction = modf(fabs(gpsdata->fix.time), &seconds);
     long sec = lrint(seconds);
     struct tm *time = gmtime(&sec);
+    unsigned int hsec = (unsigned int) lrint(fraction * 100);
+#endif
     if (time) {
       info->utc.year = (unsigned int) time->tm_year + 1900;
       info->utc.mon = (unsigned int) time->tm_mon + 1;
@@ -379,7 +403,7 @@ void nmeaInfoFromGpsd(struct gps_data_t *gpsdata, NmeaInfo *info, struct GpsdCon
       info->utc.hour = (unsigned int) time->tm_hour;
       info->utc.min = (unsigned int) time->tm_min;
       info->utc.sec = (unsigned int) time->tm_sec;
-      info->utc.hsec = (unsigned int) lrint(fraction * 100);
+      info->utc.hsec = hsec;
 
       nmeaInfoSetPresent(&info->present, NMEALIB_PRESENT_UTCDATE | NMEALIB_PRESENT_UTCTIME);
     }
@@ -387,7 +411,7 @@ void nmeaInfoFromGpsd(struct gps_data_t *gpsdata, NmeaInfo *info, struct GpsdCon
   gpsdata->set &= ~TIME_SET;
 
   /* sig & fix */
-  if (!gpsdata->online) {
+  if (!is_online(gpsdata)) {
     gpsdata->fix.mode = MODE_NO_FIX;
   }
 
@@ -454,7 +478,11 @@ void nmeaInfoFromGpsd(struct gps_data_t *gpsdata, NmeaInfo *info, struct GpsdCon
   if ((gpsdata->fix.mode >= MODE_3D) //
       && !isNaN(gpsdata->fix.altitude)) {
     info->elevation = gpsdata->fix.altitude;
+#if GPSD_API_MAJOR_VERSION >= 9
+    info->height = gpsdata->fix.geoid_sep;
+#else
     info->height = gpsdata->separation;
+#endif
     nmeaInfoSetPresent(&info->present, NMEALIB_PRESENT_ELV | NMEALIB_PRESENT_HEIGHT);
   }
   gpsdata->set &= ~ALTITUDE_SET;


### PR DESCRIPTION
The timestamp fields were changed from `double` to `struct timespec`, and
the geoid `separation` field was moved to `fix.geoid_sep`.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

This is a quick patch to let it compile.  I can't run-test this, I've just compile-tested in using openwrt master, with gpsd 3.20 and 3.19, for a mvebu/arm_cortex-a9 target.