### PR TITLE
olsrd: various bugfixes

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -123,6 +123,7 @@ int olsr_process_arguments(int argc, char *argv[], struct olsrd_config *cnf, str
      */
     if (strcmp(*argv, "-ipv6") == 0) {
       cnf->ip_version = AF_INET6;
+      cnf->ipsize = 16;
       continue;
     }
 

--- a/src/process_package.c
+++ b/src/process_package.c
@@ -370,6 +370,9 @@ deserialize_hello(struct hello_message *hello, const void *ser)
 
       limit2 += size2;
 
+      if (size2 == 0)
+        return 1;
+
       if (EXTRACT_LINK(link_code) != LINK_ORDER[idx]) {
         curr = limit2;
         continue;

--- a/src/routing_table.c
+++ b/src/routing_table.c
@@ -558,6 +558,9 @@ olsr_insert_routing_table(union olsr_ip_addr *dst, int plen, union olsr_ip_addr 
    */
   tc = olsr_locate_tc_entry(originator);
 
+  if (tc == NULL)
+    return NULL;
+
   /*
    * first check if there is a rt_path for the prefix.
    */


### PR DESCRIPTION
Two fixes encountered when running `olsrd -d 2 -ipv6 -i "uplink" -f /dev/null`, where the interface has no IPv4 address.