### PR TITLE
bmf: change include from sys/poll.h to poll.h

### DIFF
--- a/lib/bmf/src/Bmf.c
+++ b/lib/bmf/src/Bmf.c
@@ -67,7 +67,7 @@
 #include <netinet/ip.h> /* struct ip */
 #include <netinet/udp.h> /* struct udphdr */
 #include <unistd.h> /* read(), write() */
-#include <sys/poll.h> /* Daniele Lacamera: Added guard poll for sendto(), needs poll.h */
+#include <poll.h> /* Daniele Lacamera: Added guard poll for sendto(), needs poll.h */
 
 /* OLSRD includes */
 #include "plugin_util.h" /* set_plugin_int */


### PR DESCRIPTION
Musl library generates an error when including <sys/poll.h>.
POSIX specifications state that <poll.h> should be used.

Fixes warnings in the form of:
```
  [CC] src/Bmf.c
  In file included from src/Bmf.c:70:
  /home/nick/openwrt/staging_dir/toolchain-mips_24kc_gcc-8.4.0_musl
     /include/sys/poll.h:1:2: warning: #warning redirecting incorrect
     #include <sys/poll.h> to <poll.h> [-Wcpp]
   #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
```