### PR TITLE
olsrd: increase default interface metric

### DIFF
--- a/src/olsr_cfg.h
+++ b/src/olsr_cfg.h
@@ -72,7 +72,7 @@
 #define DEF_IPC_CONNECTIONS  0
 #define DEF_USE_HYST         false
 #define DEF_FIB_METRIC       FIBM_FLAT
-#define DEF_FIB_METRIC_DEFAULT            2
+#define DEF_FIB_METRIC_DEFAULT            9
 #define DEF_LQ_LEVEL         2
 #define DEF_LQ_ALGORITHM     "etx_ff"
 #define DEF_LQ_FISH          1


### PR DESCRIPTION
In order to prioritize multiple IP uplinks on an OLSRv1 gateway node the default
metric of olsr v1 routes is changed from 2 to 9.

Signed-off-by: Thomas Huehn <thomas.huehn@hs-nordhausen.de>