### PR TITLE
pud: fix openwrt glibc compilation

### DIFF
--- a/lib/pud/nmealib/Makefile.inc
+++ b/lib/pud/nmealib/Makefile.inc
@@ -68,7 +68,7 @@ COMMONCFLAGS += -Wall -Wextra -Wold-style-definition -Wdeclaration-after-stateme
                 -Wunused-parameter
 
 GCCCFLAGS    += $(COMMONCFLAGS) -fearly-inlining -finline-functions-called-once -finline-limit=350 -Wtrampolines \
-                -Wsync-nand -Wlogical-op -Wjump-misses-init -Werror
+                -Wsync-nand -Wlogical-op -Wjump-misses-init
 
 ifeq "$(GCCVERSIONGTEQ6)" "1"
 GCCCFLAGS   += -Wnull-dereference -Wshift-negative-value -Wshift-overflow -Wtautological-compare


### PR DESCRIPTION
When compiling pud with glibc it will result in

```
  error: #warning _FORTIFY_SOURCE requires compiling with optimization
   (-O) [-Werror=cpp]
  #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
    ^~~~~~~
    cc1: all warnings being treated as errors
```

To compile pud with glibc again we remove Werror.