### PR TITLE
add drophna plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ endif
 cfgparser:	$(CFGDEPS) src/builddata.o
 		$(MAKECMDPREFIX)$(MAKECMD) -C $(CFGDIR)
 
-switch:		
+switch:
 	$(MAKECMDPREFIX)$(MAKECMD) -C $(SWITCHDIR)
 
 # generate it always
@@ -174,12 +174,12 @@ install_olsrd:	install_bin
 		@echo per default.
 		@echo can be found at files/olsrd.conf.default.lq
 		@echo ==========================================================
-		mkdir -p $(ETCDIR)
-		$(MAKECMDPREFIX)if [ -e $(CFGFILE) ]; then \
-			cp -f files/olsrd.conf.default.lq $(CFGFILE).new; \
+		mkdir -p ${TOPDIR}$(ETCDIR)
+		$(MAKECMDPREFIX)if [ -e ${TOPDIR}$(CFGFILE) ]; then \
+			cp -f files/olsrd.conf.default.lq ${TOPDIR}$(CFGFILE).new; \
 			echo "Configuration file was saved as $(CFGFILE).new"; \
 		else \
-			cp -f files/olsrd.conf.default.lq $(CFGFILE); \
+			cp -f files/olsrd.conf.default.lq ${TOPDIR}$(CFGFILE); \
 		fi
 		@echo -------------------------------------------
 		@echo Edit $(CFGFILE) before running olsrd!!
@@ -234,7 +234,7 @@ rpm:
 
 # This is quite ugly but at least it works
 ifeq ($(OS),linux)
-SUBDIRS := arprefresh bmf dot_draw dyn_gw dyn_gw_plain httpinfo info jsoninfo mdns mini nameservice netjson poprouting p2pd pgraph pud quagga secure sgwdynspeed txtinfo watchdog
+SUBDIRS := arprefresh bmf dot_draw drophna dyn_gw dyn_gw_plain httpinfo info jsoninfo mdns mini nameservice netjson poprouting p2pd pgraph pud quagga secure sgwdynspeed txtinfo watchdog
 else
 ifeq ($(OS),win32)
 SUBDIRS := dot_draw httpinfo info jsoninfo mini netjson pgraph secure txtinfo
@@ -312,6 +312,18 @@ dot_draw_install:
 
 dot_draw_uninstall:
 		$(MAKECMDPREFIX)$(MAKECMD) -C lib/dot_draw DESTDIR=$(DESTDIR) uninstall
+
+drophna:
+	                $(MAKECMDPREFIX)$(MAKECMD) -C lib/drophna
+
+drophna_clean:
+	                $(MAKECMDPREFIX)$(MAKECMD) -C lib/drophna DESTDIR=$(DESTDIR) clean
+
+drophna_install:
+	                $(MAKECMDPREFIX)$(MAKECMD) -C lib/drophna DESTDIR=$(DESTDIR) install
+
+drophna_uninstall:
+	                $(MAKECMDPREFIX)$(MAKECMD) -C lib/drophna DESTDIR=$(DESTDIR) uninstall
 
 dyn_gw:
 		$(MAKECMDPREFIX)$(MAKECMD) -C lib/dyn_gw

--- a/lib/drophna/Makefile
+++ b/lib/drophna/Makefile
@@ -1,10 +1,5 @@
-# The olsr.org Optimized Link-State Routing daemon (olsrd)
-#
-# (c) by the OLSR project
-#
-# See our Git repository to find out who worked on this file
-# and thus is a copyright holder on it.
-#
+# The olsr.org Optimized Link-State Routing daemon(olsrd)
+# Copyright (c) 2014, Philipp Borgers <borgers@mi.fu-berlin.de>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -41,78 +36,27 @@
 # the copyright holders.
 #
 
-include Makefile.inc
+OLSRD_PLUGIN =	true
+PLUGIN_NAME =	olsrd_drophna
+PLUGIN_VER =	0.0.0
 
-TOPDIR = ../..
+TOPDIR =	../..
 include $(TOPDIR)/Makefile.inc
-
-
-RESOURCESDIR = ./resources
-
-SUPPORTED = 0
-ifeq ($(OS),linux)
-SUPPORTED = 1
-endif
-ifeq ($(OS),android)
-SUPPORTED = 1
-endif
-
-
-ifeq ($(SUPPORTED),0)
-
-.PHONY: all default_target install clean
-
-all: default_target
-
-default_target install clean:
-	@echo "*** $(PLUGIN_NAME) plugin not supported on $(OS), sorry!"
-
-else
-
-CFLAGS += -DPLUGIN_VER=\"$(PLUGIN_VER)\"
-
-.PHONY: all default_target install uninstall clean doc doc-clean java java-instal java-uninstall
-
-all: default_target
 
 default_target: $(PLUGIN_FULLNAME)
 
 $(PLUGIN_FULLNAME): $(OBJS) version-script.txt
 ifeq ($(VERBOSE),0)
-	@echo "[LD] $@"
+		@echo "[LD] $@"
 endif
-	$(MAKECMDPREFIX)$(CC) $(LDFLAGS) -o $(PLUGIN_FULLNAME) $(OBJS) $(LIBS)
+		$(MAKECMDPREFIX)$(CC) $(LDFLAGS) -o $(PLUGIN_FULLNAME) $(OBJS) $(LIBS)
 
-install: all
-	$(INSTALL_LIB)
-	mkdir -p "${TOPDIR}$(ETCDIR)"
-	cp "$(RESOURCESDIR)/olsrd.sgw.speed.conf" "${TOPDIR}$(ETCDIR)"
-	$(STRIP) "$(LIBDIR)/$(PLUGIN_FULLNAME)"
-ifneq ($(DOCDIR_OLSRD),)
-	mkdir -p "$(DOCDIR_OLSRD)"
-	cp "README_SGWDYNSPEED" "$(DOCDIR_OLSRD)"
-endif
+install:	$(PLUGIN_FULLNAME)
+		$(STRIP) $(PLUGIN_FULLNAME)
+		$(INSTALL_LIB)
 
 uninstall:
-ifneq ($(DOCDIR_OLSRD),)
-	rm -f "$(DOCDIR_OLSRD)/README_SGWDYNSPEED"
-	rmdir -p --ignore-fail-on-non-empty "$(DOCDIR_OLSRD)"
-endif
-	rm -f "$(LIBDIR)/lib$(PLUGIN_NAME).so" "$(LIBDIR)/$(PLUGIN_NAME)" "$(ETCDIR)/olsrd.sgw.speed.conf"
-	$(UNINSTALL_LIB)
-	rmdir -v -p --ignore-fail-on-non-empty "$(LIBDIR)" "$(ETCDIR)"
+		$(UNINSTALL_LIB)
 
 clean:
-ifeq ($(VERBOSE),0)
-	@echo "[$@]"
-endif
-	$(MAKECMDPREFIX)rm -f $(OBJS) $(SRCS:%.c=%.d) "$(PLUGIN_FULLNAME)"
-	$(MAKECMDPREFIX)$(MAKE) -C doc clean
-
-doc:
-	$(MAKECMDPREFIX)$(MAKE) -C doc all
-
-doc-clean:
-	$(MAKECMDPREFIX)$(MAKE) -C doc clean
-
-endif
+		rm -f $(OBJS) $(SRCS:%.c=%.d) $(PLUGIN_FULLNAME)

--- a/lib/drophna/README_DROPHNA
+++ b/lib/drophna/README_DROPHNA
@@ -1,0 +1,31 @@
+---------------------------------------------------------------------
+drophna PLUGIN FOR OLSRD
+---------------------------------------------------------------------
+
+This plugin is used to remove all gateway (0.0.0.0) HNA's. HNA
+messages are manipulated directly by moving the remainder of the
+message over the gateway announcement and updating the message size.
+
+An example setup would be a vpn server used to interconnect mesh
+islands. Routing to all nodes work, but none of the connected
+islands receive gateway announcements from another island.
+
+---------------------------------------------------------------------
+PLUGIN PARAMETERS (PlParam)
+---------------------------------------------------------------------
+
+None.
+
+---------------------------------------------------------------------
+SAMPLE CONFIG
+---------------------------------------------------------------------
+
+add in /etc/olsrd/olsrd.conf:
+
+LoadPlugin "olsrd_drophna.so.0.0.0"
+{
+}
+
+
+---------------------------------------------------------------------
+EOF / 06.05.2018

--- a/lib/drophna/src/olsrd_drophna.c
+++ b/lib/drophna/src/olsrd_drophna.c
@@ -1,0 +1,151 @@
+/*
+ * The olsr.org Optimized Link-State Routing daemon(olsrd)
+ * Copyright (c) 2004-2009, the olsr.org team - see HISTORY file
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ * * Neither the name of olsr.org, olsrd nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Visit http://www.olsr.org for more information.
+ *
+ * If you find this software useful feel free to make a donation
+ * to the project. For more information see the website or contact
+ * the copyright holders.
+ *
+ */
+
+#include "olsrd_drophna.h"
+
+/* -------------------------------------------------------------------------
+ * Function   : olsr_drophna_parser
+ * Description: Function to be passed to the parser engine. This function
+ *              processes the incoming message and removes any gw hna's.
+ * Input      : m      - message to parse
+ *              in_if  - interface to use (unused in this application)
+ *              ipaddr - IP-address to use (unused in this application)
+ * Output     : none
+ * Return     : false if message should be supressed, true otherwise
+ * Data Used  : none
+ * ------------------------------------------------------------------------- */
+bool
+olsrd_drophna_parser(
+    union olsr_message *m,
+    struct interface_olsr *in_if __attribute__ ((unused)),
+    union olsr_ip_addr *ipaddr __attribute__ ((unused))
+){
+
+  uint8_t olsr_msgtype;
+  olsr_reltime vtime;
+  uint16_t olsr_msgsize;
+  union olsr_ip_addr originator;
+
+  int hnasize;
+  const uint8_t *curr, *curr_end;
+  uint8_t *olsr_msgsize_p, *curr_hna, *temp_msgsize;
+
+  struct ipaddr_str buf;
+#ifdef DEBUG
+  OLSR_PRINTF(5, "Processing HNA\n");
+#endif
+
+  /* Check if everyting is ok */
+  if (!m) {
+    return false;
+  }
+  curr = (const uint8_t *)m;
+
+  /* olsr_msgtype */
+  pkt_get_u8(&curr, &olsr_msgtype);
+  if (olsr_msgtype != HNA_MESSAGE) {
+    OLSR_PRINTF(1, "not a HNA message!\n");
+    return false;
+  }
+  /* Get vtime */
+  pkt_get_reltime(&curr, &vtime);
+
+  /* olsr_msgsize */
+  pkt_get_u16(&curr, &olsr_msgsize);
+
+  /* validate originator */
+  pkt_get_ipaddress(&curr, &originator);
+  /*printf("HNA from %s\n\n", olsr_ip_to_string(&buf, &originator)); */
+
+  /* ttl */
+  pkt_ignore_u8(&curr);
+
+  /* hopcnt */
+  pkt_ignore_u8(&curr);
+
+  /* seqno */
+  pkt_ignore_u16(&curr);
+
+  /* msgtype(1) + vtime(1) + msgsize(2) + ttl(1) + hopcnt(1) + seqno(2) = 8 */
+  olsr_msgsize_p = (uint8_t *)m + 2;
+  curr_hna = (uint8_t *)m + 8 + olsr_cnf->ipsize;
+  curr_end = (const uint8_t *)m + olsr_msgsize;
+  hnasize = olsr_msgsize - 8 - olsr_cnf->ipsize;
+
+  if ((hnasize % (2 * olsr_cnf->ipsize)) != 0) {
+    OLSR_PRINTF(1, "Illegal HNA message from %s with size %d!\n",
+        olsr_ip_to_string(&buf, &originator), olsr_msgsize);
+    return false;
+  }
+
+  while (curr < curr_end) {
+    struct olsr_ip_prefix prefix;
+    union olsr_ip_addr mask;
+
+    pkt_get_ipaddress(&curr, &prefix.prefix);
+    pkt_get_ipaddress(&curr, &mask);
+    prefix.prefix_len = olsr_netmask_to_prefix(&mask);
+
+    if (is_prefix_inetgw(&prefix)) {
+      hnasize -= 2 * olsr_cnf->ipsize;
+      if (0 < hnasize) {
+        /* move the rest of the message forward over the gw HNA */
+        memmove(curr_hna, curr, curr_end - curr);
+        curr_end -= 2 * olsr_cnf->ipsize;
+        curr = curr_hna;
+
+        /* update the message size */
+        temp_msgsize = olsr_msgsize_p;
+        olsr_msgsize -= 2 * olsr_cnf->ipsize;
+        pkt_put_u16(&temp_msgsize, olsr_msgsize);
+        continue;
+      }
+      return false;
+    }
+    else
+    {
+      curr_hna += 2 * olsr_cnf->ipsize;
+    }
+  }
+  return true;
+}
+
+void olsrd_drophna_init(void) {
+}

--- a/lib/drophna/src/olsrd_drophna.h
+++ b/lib/drophna/src/olsrd_drophna.h
@@ -1,0 +1,60 @@
+/*
+ * The olsr.org Optimized Link-State Routing daemon(olsrd)
+ * Copyright (c) 2004-2009, the olsr.org team - see HISTORY file
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ * * Neither the name of olsr.org, olsrd nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Visit http://www.olsr.org for more information.
+ *
+ * If you find this software useful feel free to make a donation
+ * to the project. For more information see the website or contact
+ * the copyright holders.
+ *
+ */
+
+
+#ifndef LIB_DROPHNA_SRC_OLSRD_DROPHNA_H_
+#define LIB_DROPHNA_SRC_OLSRD_DROPHNA_H_
+
+#include "link_set.h"
+
+void olsrd_drophna_init(void);
+bool olsrd_drophna_parser(union olsr_message *m,
+		struct interface_olsr *in_if,
+		union olsr_ip_addr *ipaddr);
+
+
+#endif /* LIB_DROPHNA_SRC_OLSRD_DROPHNA_H_ */
+
+/*
+ * Local Variables:
+ * c-basic-offset: 2
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/lib/drophna/src/olsrd_plugin.c
+++ b/lib/drophna/src/olsrd_plugin.c
@@ -1,0 +1,127 @@
+
+/*
+ * The olsr.org Optimized Link-State Routing daemon(olsrd)
+ * Copyright (c) 2004, Andreas Tonnesen(andreto@olsr.org)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ * * Neither the name of olsr.org, olsrd nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Visit http://www.olsr.org for more information.
+ *
+ * If you find this software useful feel free to make a donation
+ * to the project. For more information see the website or contact
+ * the copyright holders.
+ *
+ */
+
+/*
+ * Dynamic linked library for the olsr.org olsr daemon
+ */
+
+#include "olsrd_plugin.h"
+#include "olsrd_drophna.h"
+#include "parser.h"
+#include "builddata.h"
+
+#define PLUGIN_NAME              "DROPHNA"
+#define PLUGIN_TITLE             "OLSRD drophna plugin"
+#define PLUGIN_INTERFACE_VERSION 5
+
+static void my_init(void) __attribute__ ((constructor));
+static void my_fini(void) __attribute__ ((destructor));
+
+/**
+ *Constructor
+ */
+static void
+my_init(void)
+{
+  /* Print plugin info to stdout */
+  OLSR_PRINTF(0, "%s (%s)\n", PLUGIN_NAME, git_descriptor);
+}
+
+/**
+ *Destructor
+ */
+static void
+my_fini(void)
+{
+  /* Calls the destruction function
+   * olsr_plugin_exit()
+   * This function should be present in your
+   * sourcefile and all data destruction
+   * should happen there - NOT HERE!
+   */
+  olsr_plugin_exit();
+}
+
+/**
+ *Do initialization here
+ *
+ *This function is called by the my_init
+ *function in uolsrd_plugin.c
+ */
+int olsrd_plugin_init(void) {
+  olsr_parser_add_function(&olsrd_drophna_parser, HNA_MESSAGE);
+  return 0;
+}
+
+/**
+ * destructor - called at unload
+ */
+void olsr_plugin_exit(void) {
+}
+
+static const struct olsrd_plugin_parameters plugin_parameters[] = {
+};
+
+/**
+ * Plugin interface version
+ * Used by main olsrd to check plugin interface version
+ */
+int
+olsrd_plugin_interface_version(void)
+{
+  return PLUGIN_INTERFACE_VERSION;
+}
+
+void
+olsrd_get_plugin_parameters(const struct olsrd_plugin_parameters **params, int *size)
+{
+  *params = plugin_parameters;
+  *size = sizeof(plugin_parameters) / sizeof(*plugin_parameters);
+}
+
+/*
+ * Local Variables:
+ * mode: c
+ * style: linux
+ * c-basic-offset: 2
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/lib/drophna/src/olsrd_plugin.h
+++ b/lib/drophna/src/olsrd_plugin.h
@@ -1,0 +1,67 @@
+/*
+ * The olsr.org Optimized Link-State Routing daemon (olsrd)
+ *
+ * (c) by the OLSR project
+ *
+ * See our Git repository to find out who worked on this file
+ * and thus is a copyright holder on it.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ * * Neither the name of olsr.org, olsrd nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Visit http://www.olsr.org for more information.
+ *
+ * If you find this software useful feel free to make a donation
+ * to the project. For more information see the website or contact
+ * the copyright holders.
+ *
+ */
+
+/*
+ * Dynamic linked library for the olsr.org olsr daemon
+ */
+
+#ifndef LIB_DROPHNA_SRC_OLSRD_PLUGIN_H_
+#define LIB_DROPHNA_SRC_OLSRD_PLUGIN_H_
+
+#include "plugin_util.h"
+
+int olsrd_plugin_interface_version(void);
+int olsrd_plugin_init(void);
+void olsr_plugin_exit(void);
+void olsrd_get_plugin_parameters(const struct olsrd_plugin_parameters **params, int *size);
+
+#endif /* LIB_DROPHNA_SRC_OLSRD_PLUGIN_H_ */
+
+/*
+ * Local Variables:
+ * c-basic-offset: 2
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/lib/drophna/version-script.txt
+++ b/lib/drophna/version-script.txt
@@ -1,0 +1,11 @@
+VERS_1.0
+{
+  global:
+    olsrd_plugin_interface_version;
+    olsrd_plugin_init;
+    olsrd_get_plugin_parameters;
+
+  local:
+    *;
+};
+

--- a/lib/pud/Makefile
+++ b/lib/pud/Makefile
@@ -125,8 +125,8 @@ install: all
 	$(MAKECMDPREFIX)$(MAKE) -C "$(NMEALIB_PATH)" DESTDIR="$(DESTDIR)" install
 	$(MAKECMDPREFIX)$(MAKE) -C "$(LIBRARY_PATH)" DESTDIR="$(DESTDIR)" install
 	$(INSTALL_LIB)
-	mkdir -p "$(ETCDIR)"
-	cp "$(RESOURCESDIR)/olsrd.pud.position.conf" "$(ETCDIR)"
+	mkdir -p "${TOPDIR}$(ETCDIR)"
+	cp "$(RESOURCESDIR)/olsrd.pud.position.conf" "${TOPDIR}$(ETCDIR)"
 	$(STRIP) "$(LIBDIR)/$(PLUGIN_FULLNAME)"
 ifneq ($(DOCDIR_OLSRD),)
 	mkdir -p "$(DOCDIR_OLSRD)"


### PR DESCRIPTION
some years ago, Freifunk Berlin developed this plugin which is helpful to be used on VPN servers that connect OLSR clouds.

What do you think about making this available olsrd's directly?

I merged the original branch from 2018 (https://github.com/freifunk-berlin/external_olsrd/compare/drophna...OLSR:master) into the current master branch. Everything compiled, and the plugin seems to work.
(I'm neither an OLSR developer nor a C/C++ developer, so I can't say so much about the code quality)