### PR TITLE
fix build with gpsd >= 3.23.1

### DIFF
--- a/lib/pud/src/gpsdclient.c
+++ b/lib/pud/src/gpsdclient.c
@@ -370,7 +370,9 @@ void nmeaInfoFromGpsd(struct gps_data_t *gpsdata, NmeaInfo *info, struct GpsdCon
           );
 
   gpsdata->set &= ~STATUS_SET; /* always valid */
-  #if GPSD_API_MAJOR_VERSION >= 10
+  #if GPSD_API_MAJOR_VERSION >= 12
+  if (gpsdata->fix.status == STATUS_UNK) {
+  #elif GPSD_API_MAJOR_VERSION >= 10
   if (gpsdata->fix.status == STATUS_NO_FIX) {
   #else
   if (gpsdata->status == STATUS_NO_FIX) {


### PR DESCRIPTION
Fix the following build failure raised with gpsd >= 3.23.1 and https://gitlab.com/gpsd/gpsd/-/commit/d4a4d8d3606fd50f10bcd20096a8a0cdb8b2d427:

```
src/gpsdclient.c: In function 'nmeaInfoFromGpsd':
src/gpsdclient.c:374:30: error: 'STATUS_NO_FIX' undeclared (first use in this function); did you mean 'STATUS_PPS_FIX'?
  374 |   if (gpsdata->fix.status == STATUS_NO_FIX) {
      |                              ^~~~~~~~~~~~~
      |                              STATUS_PPS_FIX
```

Fixes:
 - http://autobuild.buildroot.org/results/53b06e72fb2d8b4c8b6ba41baf775ff33654cd18

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>