### PR TITLE
 lib/pud: fix build with gpsd >= 3.25

### DIFF
--- a/lib/pud/src/gpsdclient.h
+++ b/lib/pud/src/gpsdclient.h
@@ -60,13 +60,22 @@ struct GpsdConnectionState {
     struct devconfig_t dev[MAXUSERDEVS];
 };
 
-/* describe a data source */
+/**
+ * describe a data source
+ *
+ * Starting with gpsd 3.25, this is now provided in gps.h, but we have no way
+ * to compare gpsd version as it is not provided in gps.h; all we can compare
+ * against is the API version. struct fixsource_t was moved as part  of bumping
+ * to API 14, so we compare agasint that
+ */
+#if GPSD_API_MAJOR_VERSION < 14
 struct fixsource_t {
     char spec[PATH_MAX]; /* working space, will be modified */
     char *server; /* pointer into spec field */
     char *port; /* pointer into spec field */
     char *device; /* pointer into spec field */
 };
+#endif
 
 /**
  * The gpsd daemon spec

--- a/lib/pud/src/gpsdclient.h
+++ b/lib/pud/src/gpsdclient.h
@@ -60,6 +60,14 @@ struct GpsdConnectionState {
     struct devconfig_t dev[MAXUSERDEVS];
 };
 
+/* describe a data source */
+struct fixsource_t {
+    char spec[PATH_MAX]; /* working space, will be modified */
+    char *server; /* pointer into spec field */
+    char *port; /* pointer into spec field */
+    char *device; /* pointer into spec field */
+};
+
 /**
  * The gpsd daemon spec
  */


### PR DESCRIPTION
Fix build against gpsd-3.25.

Fixes: #118
Supersedes: #119 #120 #121

This was tested to fix the build with gpsd-3.25, as detected by Buildroot autobuilders:
http://autobuild.buildroot.org/results/47a619686bb47debd525c92aa7e14bee5c40ca9e