### PR TITLE
fix compilation with GCC14

### DIFF
--- a/lib/filtergw/src/olsrd_filtergw.c
+++ b/lib/filtergw/src/olsrd_filtergw.c
@@ -77,7 +77,7 @@ struct originator_list {
 
 struct filter_group {
   struct originator_list *originator_list;
-  struct hna_group *next;
+  struct filter_group *next;
 };
 
 static struct filter_group *filter_groups = NULL;
@@ -128,7 +128,7 @@ static int set_plugin_filter(const char *value,
       olsr_exit("FILTERGW: Out of memory", EXIT_FAILURE);
     }
     filter_groups = new;
-    new->next = (struct hna_group *)filter_groups;
+    new->next = filter_groups;
   }
 
   filter_groups->originator_list =

--- a/src/linux/kernel_routes_nl.c
+++ b/src/linux/kernel_routes_nl.c
@@ -157,13 +157,13 @@ static void rtnetlink_read(int sock, void *data __attribute__ ((unused)), unsign
   struct iovec iov;
   struct sockaddr_nl nladdr;
   struct msghdr msg = {
-    &nladdr,
-    sizeof(nladdr),
-    &iov,
-    1,
-    NULL,
-    0,
-    0
+    .msg_name = &nladdr,
+    .msg_namelen = sizeof(nladdr),
+    .msg_iov = &iov,
+    .msg_iovlen = 1,
+    .msg_control = NULL,
+    .msg_controllen = 0,
+    .msg_flags = 0,
   };
 
   char buffer[4096];


### PR DESCRIPTION
the msghdr has padding in both glibc and musl. Initialize with names to avoid dealing with the padding.

There's also a wrong struct type that's an error now.