### PR TITLE
Fix build with libgps <= 3.24 using pkg-config

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -113,6 +113,7 @@ BISON ?=	bison
 FLEX ?=		flex
 LDCONFIG ?=	/sbin/ldconfig
 TAGCMD ?=	etags
+PKG_CONFIG ?=	pkg-config
 
 # target directories and names
 DESTDIR  ?=

--- a/lib/pud/Makefile
+++ b/lib/pud/Makefile
@@ -58,6 +58,9 @@ include $(TOPDIR)/Makefile.inc
 PUD_NMEALIB_STATICALLY_LINKED ?=
 CFLAGS += -D_GNU_SOURCE
 
+LIBGPS_VERSION := $(shell $(PKG_CONFIG) --modversion libgps)
+CFLAGS += -DLIBGPS_VERSION_MAJOR=$(word 1,$(subst ., ,$(LIBGPS_VERSION)))
+CFLAGS += -DLIBGPS_VERSION_MINOR=$(word 2,$(subst ., ,$(LIBGPS_VERSION)))
 
 RESOURCESDIR = ./resources
 NMEALIB_LIB = $(NMEALIB_PATH)/lib

--- a/lib/pud/src/gpsdclient.h
+++ b/lib/pud/src/gpsdclient.h
@@ -61,6 +61,20 @@ struct GpsdConnectionState {
 };
 
 /**
+ * describe a data source
+ *
+ * Starting with gpsd 3.25, this is now provided in gps.h.
+ */
+#if LIBGPS_VERSION_MAJOR <= 3 && LIBGPS_VERSION_MINOR <= 24
+struct fixsource_t {
+    char spec[PATH_MAX]; /* working space, will be modified */
+    char *server; /* pointer into spec field */
+    char *port; /* pointer into spec field */
+    char *device; /* pointer into spec field */
+};
+#endif
+
+/**
  * The gpsd daemon spec
  */
 typedef struct _GpsDaemon {


### PR DESCRIPTION
Introduce back the fixsource_t struct definition based on libgps version, retrieved from pkg-config.
This fixes the build with libgps versions inferior or equal to 3.24

Closes: https://github.com/OLSR/olsrd/pull/122 from which it is based off.
